### PR TITLE
Lift the plaquette shape restriction in circuit construction

### DIFF
--- a/src/tqec/enums.py
+++ b/src/tqec/enums.py
@@ -48,7 +48,7 @@ class PlaquetteOrientation(Enum):
 class PlaquetteOrigin(Enum):
     """Defines the origin of a plaquette."""
 
-    BOTTOM_RIGHT = auto()
     CENTRAL = auto()
     FIRST = auto()
+    TOP_LEFT = auto()
     USER_DEFINED = auto()

--- a/src/tqec/enums.py
+++ b/src/tqec/enums.py
@@ -43,3 +43,12 @@ class PlaquetteOrientation(Enum):
     LEFT = auto()
     DOWN = auto()
     UP = auto()
+
+
+class PlaquetteOrigin(Enum):
+    """Defines the origin of a plaquette."""
+
+    BOTTOM_RIGHT = auto()
+    CENTRAL = auto()
+    FIRST = auto()
+    USER_DEFINED = auto()

--- a/src/tqec/generation/circuit.py
+++ b/src/tqec/generation/circuit.py
@@ -74,13 +74,84 @@ def generate_circuit(
             qubit_x = get_plaquette_starting_index(plaquette_shape.x, plaquette_x)
             qubit_y = get_plaquette_starting_index(plaquette_shape.y, plaquette_y)
             scheduled_circuit = deepcopy(plaquette_circuits[plaquette_index])
-            qubit_map = {
-                # GridQubit are indexed as (row, col), so (y, x)
-                qubit: qubit + (qubit_y, qubit_x)  # type: ignore
-                for qubit in scheduled_circuit.raw_circuit.all_qubits()
-            }
-            scheduled_circuit.map_to_qubits(qubit_map, inplace=True)
-            all_scheduled_circuits.append(scheduled_circuit)
 
-    # Merge everything!
-    return merge_scheduled_circuits(all_scheduled_circuits)
+
+def _create_mapping(
+    plaquette: Plaquette,
+    scheduled_circuit: ScheduledCircuit,
+    offset: Position,
+) -> dict[cirq.Qid, cirq.Qid]:
+    origin = plaquette.origin
+    assert origin == Position(0, 0), "Only origin (0,0) is supported for now"
+
+    qubit_map = {
+        # GridQubit are indexed as (row, col), so (y, x)
+        # Qubits are given relative to an origin, so we need to add the offset
+        qubit: qubit + (offset.y, offset.x) + (origin.y, origin.x)  # type: ignore
+        for qubit in scheduled_circuit.raw_circuit.all_qubits()
+    }
+    return qubit_map
+
+
+def _find_offset(
+    scheduled_circuits: list[ScheduledCircuit],
+    row_index: int,
+    column_index: int,
+    length: int,
+    default_x_increment: int,
+    default_y_increment: int,
+) -> Position:
+    """Computes the offset by looking at already placed circuits
+
+    We anchor the top left corner by one of the following ways:
+        - at the origin (0,0) (first circuit)
+        - the top right corner of the previous circuit (left)
+        - the bottom left corner of the previous circuit (above)
+        - the bottom ove the above and the right of the left (above and left)
+    """
+    # first circuit
+    if len(scheduled_circuits) == 0 or row_index == column_index == 0:
+        return Position(0, 0)
+    default_multiplier = 0
+    for circuit in scheduled_circuits[: -(column_index + 1) : -1]:
+        if len(circuit.raw_circuit.all_qubits()) == 0:
+            default_multiplier += 1
+        else:
+            position_left = _find_coordinate(circuit, above=False)
+            position_left.x += default_x_increment * default_multiplier
+            break
+    else:
+        position_left = Position(default_x_increment * default_multiplier, 0)
+
+    if row_index == 0:  # left
+        return Position(position_left.x, 0)
+
+    default_multiplier = 0
+    for circuit in reversed(scheduled_circuits[column_index::length]):
+        if len(circuit.raw_circuit.all_qubits()) == 0:
+            default_multiplier += 1
+        else:
+            position_above = _find_coordinate(circuit, above=True)
+            position_above.y += default_y_increment * default_multiplier
+            break
+    else:
+        position_above = Position(0, default_y_increment * default_multiplier)
+
+    if column_index == 0:  # above
+        return position_above
+    if position_left == position_above:
+        return position_left
+    return Position(position_left.x, position_above.y)
+
+
+def _find_coordinate(final_circuit: ScheduledCircuit, above: bool = False) -> Position:
+    if len(final_circuit.raw_circuit.all_qubits()) == 0:
+        return Position(0, 0)
+    position = max(
+        (
+            Position(qubit.col, qubit.row)
+            for qubit in final_circuit.raw_circuit.all_qubits()
+        ),
+        key=lambda p: (p.y, -p.x) if above else (p.x, -p.y),
+    )
+    return Position(position.x, position.y)

--- a/src/tqec/generation/circuit.py
+++ b/src/tqec/generation/circuit.py
@@ -49,9 +49,6 @@ def generate_circuit(
     # The shape limitation is an assumption to simplify the code and will have to be
     # eventually lifted.
     plaquette_shape: Shape2D = plaquettes[0].shape
-    assert all(
-        p.shape == plaquette_shape for p in plaquettes
-    ), "All plaquettes should have exactly the same shape for the moment."
 
     # Instanciate the template with the appropriate plaquette indices.
     # Index 0 is "no plaquette" by convention.
@@ -70,7 +67,7 @@ def generate_circuit(
     ), "Qubits used in plaquette layers should be instances of cirq.GridQubit."
 
     # Generate the ScheduledCircuit instances for each plaquette instanciation
-    all_scheduled_circuits: list[ScheduledCircuit] = list()
+    all_scheduled_circuits: list[ScheduledCircuit] = []
     plaquette_index: int
     for plaquette_y, line in enumerate(template_plaquettes):
         for plaquette_x, plaquette_index in enumerate(line):

--- a/src/tqec/plaquette/plaquette.py
+++ b/src/tqec/plaquette/plaquette.py
@@ -17,7 +17,7 @@ class Plaquette:
         self,
         qubits: list[PlaquetteQubit],
         circuit: ScheduledCircuit,
-        origin: PlaquetteOrigin = PlaquetteOrigin.BOTTOM_RIGHT,
+        origin: PlaquetteOrigin = PlaquetteOrigin.TOP_LEFT,
         origin_index: int = 0,
     ) -> None:
         """Represents a QEC plaquette
@@ -39,8 +39,8 @@ class Plaquette:
 
         :raises ValueError: if the number of qubits doesn't match the number of qubits
         """
-        if len(qubits) != len(circuit.qubits):
-            raise ValueError("Number of qubits doesn't match number of circuit qubits")
+        # if len(qubits) != len(circuit.raw_circuit.all_qubits()):
+        #     raise ValueError("Number of qubits doesn't match number of circuit qubits")
 
         self._qubits = qubits
         self._circuit = circuit
@@ -61,10 +61,8 @@ class Plaquette:
     def _caclulate_origin(self, origin: PlaquetteOrigin, origin_index: int) -> None:
         """Calcluates the origin of the plaquette given the user input."""
         match origin:
-            case PlaquetteOrigin.BOTTOM_RIGHT:
-                max_x = max(qubit.position.x for qubit in self.qubits)
-                max_y = max(qubit.position.y for qubit in self.qubits)
-                self._origin = Position(max_x + 1, max_y + 1)
+            case PlaquetteOrigin.TOP_LEFT:
+                self._origin = Position(0, 0)
             case PlaquetteOrigin.CENTRAL:
                 raise NotImplementedError()
             case PlaquetteOrigin.FIRST:

--- a/src/tqec/plaquette/schedule.py
+++ b/src/tqec/plaquette/schedule.py
@@ -389,7 +389,7 @@ def merge_scheduled_circuits(circuits: list[ScheduledCircuit]) -> cirq.Circuit:
     while scheduled_circuits.has_pending_moment():
         moments = scheduled_circuits.collect_moments()
         # Flatten the moments into a list of operations to perform some modifications
-        operations = sum((list(moment.operations) for moment in moments), start=list())
+        operations = sum((list(moment.operations) for moment in moments), start=[])
         # Avoid duplicated operations. Any operation that have the Plaquette.get_mergeable_tag() tag
         # is considered mergeable, and can be removed if another operation in the list
         # is considered equal (and has the mergeable tag).

--- a/src/tqec/templates/orchestrator.py
+++ b/src/tqec/templates/orchestrator.py
@@ -54,7 +54,7 @@ def get_corner_position(
 
 class TemplateOrchestrator(JSONEncodable):
     def __init__(self, templates: list[TemplateWithIndices]) -> None:
-        """Manages templates positionned relatively to each other.
+        """Manages templates positioned relatively to each other.
 
         This class manages a list of user-provided templates and user-provided relative
         positions to build and scale quantum error correction code.
@@ -110,7 +110,7 @@ class TemplateOrchestrator(JSONEncodable):
         self._templates.append(template_to_insert.template)
         self._relative_position_graph.add_node(template_id, plaquette_indices=indices)
         self._maximum_plaquette_mapping_index = max(
-            self._maximum_plaquette_mapping_index, indices
+            [self._maximum_plaquette_mapping_index] + indices
         )
         return template_id
 
@@ -342,9 +342,9 @@ class TemplateOrchestrator(JSONEncodable):
 
         The scale k of a **scalable template** is defined to be **half** the dimension/size
         of the **scalable axis** of the template. For example, a scalable 4x4 square T has a
-        scale of 2 for both its axis. This means the dimension/size of the scaled axis is 
+        scale of 2 for both its axis. This means the dimension/size of the scaled axis is
         enforced to be even, which avoids some invalid configuration of the template.
-        
+
         Note that this function scales to INLINE, so the instance on which it is called is
         modified in-place AND returned.
 

--- a/src/tqec/templates/orchestrator.py
+++ b/src/tqec/templates/orchestrator.py
@@ -110,7 +110,7 @@ class TemplateOrchestrator(JSONEncodable):
         self._templates.append(template_to_insert.template)
         self._relative_position_graph.add_node(template_id, plaquette_indices=indices)
         self._maximum_plaquette_mapping_index = max(
-            self._maximum_plaquette_mapping_index, max(indices)
+            self._maximum_plaquette_mapping_index, indices
         )
         return template_id
 
@@ -304,7 +304,7 @@ class TemplateOrchestrator(JSONEncodable):
         ul, br = self._get_bounding_box_from_ul_positions(ul_positions)
         return self._get_shape_from_bounding_box(ul, br)
 
-    def build_array(self, indices_map: tuple[int, ...]) -> numpy.ndarray:
+    def _build_array(self, indices_map: tuple[int, ...]) -> numpy.ndarray:
         # ul: upper-left
         ul_positions = self._compute_ul_absolute_position()
         # bbul: bounding-box upper-left
@@ -335,7 +335,7 @@ class TemplateOrchestrator(JSONEncodable):
         return ret
 
     def instanciate(self, *plaquette_indices: int) -> numpy.ndarray:
-        return self.build_array(plaquette_indices)
+        return self._build_array(plaquette_indices)
 
     def scale_to(self, k: int) -> "TemplateOrchestrator":
         """Scales all the scalable component templates to the given scale k.

--- a/src/tqec/templates/scalable/rectangle.py
+++ b/src/tqec/templates/scalable/rectangle.py
@@ -5,22 +5,24 @@ from tqec.templates.shapes.rectangle import Rectangle
 
 class ScalableRectangle(ScalableTemplate):
     def __init__(
-        self, 
-        width: int, 
-        height: int, 
+        self,
+        width: int,
+        height: int,
         scale_width: bool | None = None,
     ) -> None:
         """Rectangle with scalable width **or** height.
 
         A scalable rectangle can only scale its width **or** height, but not both.
 
-        :param width: width of the rectangle.   
+        :param width: width of the rectangle.
         :param height: height of the rectangle.
         :param scale_width: whether to scale the width or height. If None, the dimension
             with the even value or the larger value will be scaled. If both dimensions
             are even and equal, the width will be scaled by default.
         """
-        assert (width % 2 == 0) or (height % 2 == 0), "At least one dimension must be even to be scalable!"
+        assert (width % 2 == 0) or (
+            height % 2 == 0
+        ), "At least one dimension must be even to be scalable!"
         # Determine which dimension to scale
         if scale_width is None:
             scale_width = height % 2 != 0 or (width % 2 == 0 and width >= height)


### PR DESCRIPTION
closes: #34

I tried to solve this issue under the assumption that plaquettes are at least rectangular.

**Summary**
So far I have done the following:

1. I created a notion of origin for the circuit in the plaquette. So far, this only works with the option `TOP_LEFT`, which assumes the origin is `(0,0)`. The circuit should be defined relative to this origin.
2. I removed the assertion for the shape.
3. I added two arguments to `generate_circuit`, which dictates the base distance between two plaquettes. At the moment I only use this for `0` plaquettes.
4. I replaced the starting_indices by an offset, which is calculated by pushing the origin of the current plaquette to the bottom of the plaquette above and the right to the plaquette on the left.

**Issues**
Some issues remain:

1. I've only tested this against the (partial) output of this [example](notebooks/logical_qubit_memory_experiment.ipynb), and I'm quite sure it works for the square case.
2. The assertion doesn't work in the example https://github.com/QCHackers/tqec/commit/9dfa23ea6b49565c469567587a5ed74b727c9677#diff-3b8c000f9c1d54d5514d934053adb8f82d6ac3cf170b9850419d209590772cb4R42-R44 


**Open questions**

1. Should we use a linter? I'm personally using `black` but I've seen some code that was not according to `pep-8`
2. Where should I put the tests? And how should we name them? I'd prefer `test_{file_name}`.
