### PR TITLE
Fix typo and naming

### DIFF
--- a/specification/schemas/template.schema.json
+++ b/specification/schemas/template.schema.json
@@ -29,7 +29,7 @@
               "description": "Raw plaquette indices in the 'raw_rectangle'.",
               "items": {
                 "type": "array",
-                "items": {"type": "integer", "description": "Plaquette indices used to instanciate the template."}
+                "items": {"type": "integer", "description": "Plaquette indices used to instantiate the template."}
               }
             },
             {

--- a/src/tqec/display.py
+++ b/src/tqec/display.py
@@ -12,11 +12,11 @@ def display_template(
 
     :param template: the Template instance to display.
     :param plaquette_indices: the plaquette indices that are forwarded to the
-        call to template.instanciate to get the actual template representation.
+        call to template.instantiate to get the actual template representation.
     """
     if isinstance(template, TemplateOrchestrator) and len(plaquette_indices) == 0:
         plaquette_indices = tuple(range(template.expected_plaquettes_number))
-    arr = template.instanciate(*plaquette_indices)
+    arr = template.instantiate(*plaquette_indices)
     for line in arr:
         for element in line:
             element = str(element) if element != 0 else "."
@@ -41,7 +41,7 @@ def display_templates_svg(
     :param write_svg_file: the path to the SVG file to write.
     :param canvas_height: the height of the canvas in pixels to draw on.
     :param plaquette_indices: the plaquette indices that are forwarded to the
-        call to template.instanciate to get the actual template representation.
+        call to template.instantiate to get the actual template representation.
 
     :return: the SVG string.
     """
@@ -102,7 +102,7 @@ def display_templates_svg(
             plaquette_indices[k]
             for k in templates._relative_position_graph.nodes[i]["plaquette_indices"]
         ]
-        arr = template.instanciate(*indices)
+        arr = template.instantiate(*indices)
         outer_rects.extend(
             rect(ul_position.x, ul_position.y, len(arr[0]), len(arr), outmost=True)
         )

--- a/src/tqec/generation/circuit.py
+++ b/src/tqec/generation/circuit.py
@@ -17,7 +17,7 @@ def generate_circuit(
 
     This is one of the core methods of the `tqec` package. It generates a quantum circuit
     from the description of the template that should be implemented as well as the plaquettes
-    that should be used to instanciate the provided template.
+    that should be used to instantiate the provided template.
 
     This function requires that a few pre-conditions on the inputs are met:
     1. the number of plaquettes provided should match the number of plaquettes required by
@@ -58,17 +58,17 @@ def generate_circuit(
             "See https://github.com/QCHackers/tqec/issues/34."
         )
 
-    # Instanciate the template with the appropriate plaquette indices.
+    # instantiate the template with the appropriate plaquette indices.
     # Index 0 is "no plaquette" by convention.
     _indices = list(range(len(plaquettes) + 1))
-    template_plaquettes = template.instanciate(*_indices)
+    template_plaquettes = template.instantiate(*_indices)
     # Plaquettes indices are starting at 1 in template_plaquettes. To avoid
     # offsets in the following code, we add an empty circuit at position 0.
     plaquette_circuits = [ScheduledCircuit(cirq.Circuit())] + [
         p.circuit for p in plaquettes
     ]
 
-    # Generate the ScheduledCircuit instances for each plaquette instanciation
+    # Generate the ScheduledCircuit instances for each plaquette instantiation
     all_scheduled_circuits: list[ScheduledCircuit] = list()
     plaquette_index: int
     for plaquette_y, line in enumerate(template_plaquettes):

--- a/src/tqec/noise_models/after_clifford_depolarization.py
+++ b/src/tqec/noise_models/after_clifford_depolarization.py
@@ -48,7 +48,7 @@ class AfterCliffordDepolarizingNoise(BaseNoiseModel):
 
     def noisy_operation(self, operation: cirq.Operation) -> cirq.OP_TREE:
         if isinstance(operation, cirq.CircuitOperation):
-            return self.recurse_in_operation_if_CircuitOperation(operation)
+            return self.recurse_in_operation_if_circuit_operation(operation)
         elif is_clifford(operation):
             return [
                 operation,

--- a/src/tqec/noise_models/after_reset_flip.py
+++ b/src/tqec/noise_models/after_reset_flip.py
@@ -25,4 +25,4 @@ class AfterResetFlipNoise(BaseNoiseModel):
                 ],
             ]
         else:
-            return self.recurse_in_operation_if_CircuitOperation(operation)
+            return self.recurse_in_operation_if_circuit_operation(operation)

--- a/src/tqec/noise_models/base.py
+++ b/src/tqec/noise_models/base.py
@@ -12,7 +12,7 @@ class BaseNoiseModel(cirq.NoiseModel):
         )
         super().__init__()
 
-    def recurse_in_operation_if_CircuitOperation(
+    def recurse_in_operation_if_circuit_operation(
         self, operation: cirq.Operation
     ) -> cirq.OP_TREE:
         """Helper method to handle cirq.CircuitOperation nearly transparently

--- a/src/tqec/noise_models/before_measure_flip.py
+++ b/src/tqec/noise_models/before_measure_flip.py
@@ -25,4 +25,4 @@ class BeforeMeasurementFlipNoise(BaseNoiseModel):
                 operation,
             ]
         else:
-            return self.recurse_in_operation_if_CircuitOperation(operation)
+            return self.recurse_in_operation_if_circuit_operation(operation)

--- a/src/tqec/noise_models/idle_qubits.py
+++ b/src/tqec/noise_models/idle_qubits.py
@@ -28,7 +28,7 @@ class DepolarizingNoiseOnIdlingQubit(BaseNoiseModel):
 
         # Apply recursively the noise model to CircuitOperation instances
         moment = cirq.Moment(
-            self.recurse_in_operation_if_CircuitOperation(op) for op in moment
+            self.recurse_in_operation_if_circuit_operation(op) for op in moment
         )
         # Apply the noise model to the moment at hand, not recursing into
         # any CircuitOperation instances

--- a/src/tqec/noise_models/multi_qubit_gates.py
+++ b/src/tqec/noise_models/multi_qubit_gates.py
@@ -20,7 +20,7 @@ class MultiQubitDepolarizingNoiseAfterMultiQubitGate(BaseNoiseModel):
         qubit_number = len(operation.qubits)
         if qubit_number > 1:
             if isinstance(operation, cirq.CircuitOperation):
-                return self.recurse_in_operation_if_CircuitOperation(operation)
+                return self.recurse_in_operation_if_circuit_operation(operation)
             else:
                 return [
                     operation,

--- a/src/tqec/templates/base.py
+++ b/src/tqec/templates/base.py
@@ -46,7 +46,7 @@ class JSONEncodable(ABC):
         """
         if "default" in kwargs:
             raise TQECException(
-                f"The 'default' key has been found with value '{kwargs.get("default")}' in the provided kwargs."
+                f"The 'default' key has been found with value '{kwargs.get('default')}' in the provided kwargs."
                 " 'default' key is prohibited in the public API as it is changed internally."
             )
         return json.dumps(self.to_dict(), default=_json_encoding_default, **kwargs)
@@ -67,15 +67,15 @@ class Template(JSONEncodable):
         super().__init__()
         self._shape_instance = shape
 
-    def instanciate(self, *plaquette_indices: int) -> numpy.ndarray:
+    def instantiate(self, *plaquette_indices: int) -> numpy.ndarray:
         """Generate the numpy array representing the template.
 
         :param plaquette_indices: the plaquette indices that will be forwarded to the
-            underlying Shape instance's instanciate method.
+            underlying Shape instance's instantiate method.
         :returns: a numpy array with the given plaquette indices arranged according
             to the underlying shape of the template.
         """
-        return self._shape_instance.instanciate(*plaquette_indices)
+        return self._shape_instance.instantiate(*plaquette_indices)
 
     @property
     def shape(self) -> Shape2D:
@@ -132,7 +132,7 @@ class Template(JSONEncodable):
 
 @dataclass
 class TemplateWithIndices:
-    """A wrapper around a Template instance and the indices representing the plaquettes it should be instanciated with."""
+    """A wrapper around a Template instance and the indices representing the plaquettes it should be instantiated with."""
 
     template: Template
     indices: list[int]

--- a/src/tqec/templates/orchestrator.py
+++ b/src/tqec/templates/orchestrator.py
@@ -333,12 +333,12 @@ class TemplateOrchestrator(JSONEncodable):
             x = tul.x - bbul.x
             y = tul.y - bbul.y
             # Numpy indexing is (y, x) in our coordinate system convention.
-            ret[y : y + tshapey, x : x + tshapex] = template.instanciate(
+            ret[y : y + tshapey, x : x + tshapex] = template.instantiate(
                 *plaquette_indices
             )
         return ret
 
-    def instanciate(self, *plaquette_indices: int) -> numpy.ndarray:
+    def instantiate(self, *plaquette_indices: int) -> numpy.ndarray:
         return self.build_array(plaquette_indices)
 
     def scale_to(self, k: int) -> "TemplateOrchestrator":

--- a/src/tqec/templates/shapes/base.py
+++ b/src/tqec/templates/shapes/base.py
@@ -18,7 +18,7 @@ class BaseShape(ABC):
         super().__init__()
 
     @abstractmethod
-    def instanciate(self, *_: int) -> numpy.ndarray:
+    def instantiate(self, *_: int) -> numpy.ndarray:
         pass
 
     @property

--- a/src/tqec/templates/shapes/rectangle.py
+++ b/src/tqec/templates/shapes/rectangle.py
@@ -11,7 +11,7 @@ class Rectangle(BaseShape):
         self._width = width
         self._height = height
 
-    def instanciate(self, x_plaquette: int, z_plaquette: int, *_: int) -> numpy.ndarray:
+    def instantiate(self, x_plaquette: int, z_plaquette: int, *_: int) -> numpy.ndarray:
         ret = numpy.zeros(self.shape.to_numpy_shape(), dtype=int)
         odd = slice(0, None, 2)
         even = slice(1, None, 2)
@@ -54,9 +54,9 @@ class RawRectangle(Rectangle):
         super().__init__(width, height)
         self._indices = indices
 
-    def instanciate(self, *plaquette_indices: int) -> numpy.ndarray:
+    def instantiate(self, *plaquette_indices: int) -> numpy.ndarray:
         try:
-            # Use numpy indexing to instanciate the raw values.
+            # Use numpy indexing to instantiate the raw values.
             plaquette_indices_array = numpy.array(plaquette_indices, dtype=int)
             indices = numpy.array(self._indices, dtype=int)
             return plaquette_indices_array[indices]

--- a/src/tqec/templates/shapes/square.py
+++ b/src/tqec/templates/shapes/square.py
@@ -54,7 +54,7 @@ class AlternatingCornerSquare(AlternatingSquare):
         super().__init__(dimension)
         self._corner_position = corner_position
 
-    def instanciate(
+    def instantiate(
         self,
         x_plaquette: int,
         z_plaquette: int,


### PR DESCRIPTION
1. "instanciate" -> "instantiate"
2. `recurse_in_operation_if_CircuitOperation` -> `recurse_in_operation_if_circuit_operation`