### PR TITLE
Change the docstring style to Google style

### DIFF
--- a/src/tqec/detectors/measurement_map.py
+++ b/src/tqec/detectors/measurement_map.py
@@ -24,7 +24,8 @@ class CircuitMeasurementMap:
         This class provides a method to recover the global record offset of a given
         measurement from local information about this measurement.
 
-        :param circuit: the circuit instance to analyse.
+        Args:
+            circuit: the circuit instance to analyse.
         """
         flattened_circuit = flatten(circuit)
         (
@@ -42,21 +43,30 @@ class CircuitMeasurementMap:
         with their local temporal description and to recover the global offset that should be
         used to get the measurement result from the global measurement record.
 
-        :param current_moment_index: the moment index for which we want to compute the offset.
-            This method will only backtrack in time, and so will never return measurements that
-            are performed after the moment provided in this parameter. Also, the measurement
-            record offset is a local quantity that might change in time (due to subsequent
-            measurements shifting the offset), meaning that the returned offset should only be
-            considered valid for the moment provided here, and for no other moments.
-        :param qubit: qubit instance the measurement we are searching for has been performed on.
-        :param measurement_offset: the temporally-local, negative, measurement offset. A value of
-            -1 means "the last measurement performed on this qubit" ("last" should always be read
-            as "last from the current_moment_index moment view"), -2 means "the measurement just
-            before the last measurement performed on this qubit", etc.
-        :returns: the global measurement record offset, only valid for the provided
+        Args:
+            current_moment_index: the moment index for which we want to compute
+                the offset. This method will only backtrack in time, and so will
+                never return measurements that are performed after the moment
+                provided in this parameter. Also, the measurement record offset
+                is a local quantity that might change in time (due to subsequent
+                measurements shifting the offset), meaning that the returned
+                offset should only be considered valid for the moment provided
+                here, and for no other moments.
+            qubit: qubit instance the measurement we are searching for has been
+                performed on.
+            measurement_offset: the temporally-local, negative, measurement
+                offset. A value of -1 means "the last measurement performed on
+                this qubit" ("last" should always be read as "last from the
+                current_moment_index moment view"), -2 means "the measurement
+                just before the last measurement performed on this qubit", etc.
+
+        Returns:
+            the global measurement record offset, only valid for the provided
             current_moment_index, or None if the searched offset does not exist.
 
-        :raises PositiveMeasurementOffsetError: if the provided measurement_offset value is positive.
+        Raises:
+            PositiveMeasurementOffsetError: if the provided measurement_offset
+                value is positive.
         """
         if measurement_offset >= 0:
             raise TQECException(
@@ -106,19 +116,26 @@ class CircuitMeasurementMap:
 
         The provided circuit should not contain any cirq.CircuitOperation instance.
 
-        :param circuit: circuit to compute the global measurements of.
-        :param _measurement_offset: offset applied to the indices of each measurements. Used for the
-            recursive calls.
-        :returns: a tuple (global_measurement_indices, global_measurement_index).
-            - global_measurement_indices is a list containing one entry for each Moment in the provided
+        Args:
+            circuit: circuit to compute the global measurements of.
+            _measurement_offset: offset applied to the indices of each
+                measurement. Used for the recursive calls.
+
+        Returns:
+            a tuple (global_measurement_indices, global_measurement_index). -
+            global_measurement_indices is a list containing one entry for each
+            Moment in the provided
               circuit. The entry for a given Moment corresponds to a mapping from the qubit instance that
               has been measured and the global measurement index (again, measurements in repeated
               cirq.CircuitOperation instances are only counted once).
             - global_measurement_index is an integer representing the index of the next measurement that
               will be encountered. It is part of the return API to simplify the recursion, and should not
               be useful for the external caller.
-        :raises MeasurementAppliedOnMultipleQubits: if the provided cirq.AbstractCircuit instance contains
-            measurements applied on several qubits at the same time.
+
+        Raises:
+            MeasurementAppliedOnMultipleQubits: if the provided
+                cirq.AbstractCircuit instance contains measurements applied on
+                several qubits at the same time.
         """
         global_measurement_indices: list[dict[cirq.Qid, int]] = []
         global_measurement_index: int = _measurement_offset
@@ -145,13 +162,16 @@ def compute_global_measurements_lookback_offsets(
     This method uses the global data computed in the CircuitMeasurementMap instance given as
     parameter to compute the measurement record indices for the current gate instance.
 
-    :param relative_measurements_record: the record of relative measurements to compute global
-        measurements offset from.
-    :param measurement_map: global measurement data obtained from the complete quantum circuit.
-    :param current_moment_index: index of the moment this gate instance is found in. Used to
-        recover the correct data from the given measurement_map.
+    Args:
+        relative_measurements_record: the record of relative measurements to
+            compute global measurements offset from.
+        measurement_map: global measurement data obtained from the complete
+            quantum circuit.
+        current_moment_index: index of the moment this gate instance is found
+            in. Used to recover the correct data from the given measurement_map.
 
-    :return: the computed list of global measurements lookback offsets.
+    Returns:
+        the computed list of global measurements lookback offsets.
     """
     global_measurements_lookback_offsets = []
     origin = relative_measurements_record.origin

--- a/src/tqec/detectors/operation.py
+++ b/src/tqec/detectors/operation.py
@@ -83,12 +83,13 @@ class RelativeMeasurementsRecord(cirq.Operation):
         """A group of relative measurement data representing measurements relative
         to the origin of local coordinate system and current measurement timestamp.
 
-        :param local_coordinate_system_origin: origin of the local coordinate system. 
-            The origin along with the local coordinate system will be pinned to the 
-            global coordinate system to resolve the actual qubit coordinates the 
-            measurements applied to.
-        :param data: a list of :class:`RelativeMeasurementData` that composed the
-            relative measurements' operation.
+        Args:
+            local_coordinate_system_origin: origin of the local coordinate
+                system. The origin along with the local coordinate system will
+                be pinned to the global coordinate system to resolve the actual
+                qubit coordinates the measurements applied to.
+            data: a list of :class:`RelativeMeasurementData` that composed the
+                relative measurements' operation.
         """
         self._local_coordinate_system_origin = local_coordinate_system_origin
         self._data = data
@@ -139,14 +140,15 @@ class Detector(RelativeMeasurementsRecord):
         with the correct tags. Otherwise, you might need to manually tag the operation with the
         `cirq.VirtualTag` and the `STIM_TAG`.
 
-        :param local_coordinate_system_origin: origin of the local coordinate system.
-            The origin along with the local coordinate system will be pinned to the
-            global coordinate system to resolve the actual qubit coordinates the
-            measurements applied to.
-        :param data: a list of :class:`RelativeMeasurementData` that composed the
-            relative measurements' operation.
-        :param time_coordinate: an annotation that will be forwarded to the DETECTOR
-            Stim structure as the last coordinate.
+        Args:
+            local_coordinate_system_origin: origin of the local coordinate
+                system. The origin along with the local coordinate system will
+                be pinned to the global coordinate system to resolve the actual
+                qubit coordinates the measurements applied to.
+            data: a list of :class:`RelativeMeasurementData` that composed the
+                relative measurements' operation.
+            time_coordinate: an annotation that will be forwarded to the
+                DETECTOR Stim structure as the last coordinate.
         """
         super().__init__(local_coordinate_system_origin, data)
         self._time_coordinate = time_coordinate
@@ -187,13 +189,14 @@ class Observable(RelativeMeasurementsRecord):
         with the correct tags. Otherwise, you might need to manually tag the operation with the
         `cirq.VirtualTag` and the `STIM_TAG`.
 
-        :param local_coordinate_system_origin: origin of the local coordinate system.
-            The origin along with the local coordinate system will be pinned to the
-            global coordinate system to resolve the actual qubit coordinates the
-            measurements applied to.
-        :param data: a list of :class:`RelativeMeasurementData` that composed the
-            relative measurements' operation.
-        :param observable_index: the index of the observable.
+        Args:
+            local_coordinate_system_origin: origin of the local coordinate
+                system. The origin along with the local coordinate system will
+                be pinned to the global coordinate system to resolve the actual
+                qubit coordinates the measurements applied to.
+            data: a list of :class:`RelativeMeasurementData` that composed the
+                relative measurements' operation.
+            observable_index: the index of the observable.
         """
         super().__init__(local_coordinate_system_origin, data)
         self._observable_index = observable_index
@@ -211,9 +214,11 @@ def make_shift_coords(*shifts: int) -> cirq.Operation:
     """This is a helper function to make a :class:~ShiftCoords operation with the
     `cirq.VirtualTag` tag.
 
-    :param shifts: How much to shift each coordinate.
+    Args:
+        *shifts: How much to shift each coordinate.
 
-    :return: A :class:`ShiftCoords` operation with the `cirq.VirtualTag` tag.
+    Returns:
+        A :class:`ShiftCoords` operation with the `cirq.VirtualTag` tag.
     """
     return ShiftCoords(*shifts).with_tags(cirq.VirtualTag(), STIM_TAG)
 
@@ -226,21 +231,24 @@ def make_detector(
     """This is a helper function to make a :class:`Detector` operation with the
     `cirq.VirtualTag` tag.
 
-    :param local_coordinate_system_origin: origin of the local coordinate system.
-        The origin along with the local coordinate system will be pinned to the
-        global coordinate system to resolve the actual qubit coordinates the
-        measurements applied to.
-    :param relative_measurements: a list of relative measurements that compose the
-        parity check of the detector. Each element of the list is a tuple of
-        (relative_qubit_position, relative_measurement_offset) or a :class:`RelativeMeasurementData`
-        instance. When a tuple is provided, the first element is the position of
-        the qubit relative to the local coordinate system origin and the second element
-        is the relative measurement offset with respect to the most recent measurement
-        performed on the qubit.
-    :param time_coordinate: an annotation that will be forwarded to the DETECTOR
-        Stim structure as the last coordinate.
+    Args:
+        local_coordinate_system_origin: origin of the local coordinate system.
+            The origin along with the local coordinate system will be pinned to
+            the global coordinate system to resolve the actual qubit coordinates
+            the measurements applied to.
+        relative_measurements: a list of relative measurements that compose the
+            parity check of the detector. Each element of the list is a tuple of
+            (relative_qubit_position, relative_measurement_offset) or a
+            :class:`RelativeMeasurementData` instance. When a tuple is provided,
+            the first element is the position of the qubit relative to the local
+            coordinate system origin and the second element is the relative
+            measurement offset with respect to the most recent measurement
+            performed on the qubit.
+        time_coordinate: an annotation that will be forwarded to the DETECTOR
+            Stim structure as the last coordinate.
 
-    :return: A :class:`Detector` operation with the `cirq.VirtualTag` tag.
+    Returns:
+        A :class:`Detector` operation with the `cirq.VirtualTag` tag.
     """
     relative_measurements_data = [
         RelativeMeasurementData(*rm) if not isinstance(rm, RelativeMeasurementData) else rm
@@ -261,20 +269,23 @@ def make_observable(
     """This is a helper function to make a :class:`Observable` operation with the
     `cirq.VirtualTag` tag.
 
-    :param local_coordinate_system_origin: origin of the local coordinate system.
-        The origin along with the local coordinate system will be pinned to the
-        global coordinate system to resolve the actual qubit coordinates the
-        measurements applied to.
-    :param relative_measurements: a list of relative measurements that compose the
-        parity check of the observable. Each element of the list is a tuple of
-        (relative_qubit_position, relative_measurement_offset) or a :class:`RelativeMeasurementData`
-        instance. When a tuple is provided, the first element is the position of
-        the qubit relative to the local coordinate system origin and the second element
-        is the relative measurement offset with respect to the most recent measurement
-        performed on the qubit.
-    :param observable_index: the index of the observable.
+    Args:
+        local_coordinate_system_origin: origin of the local coordinate system.
+            The origin along with the local coordinate system will be pinned to
+            the global coordinate system to resolve the actual qubit coordinates
+            the measurements applied to.
+        relative_measurements: a list of relative measurements that compose the
+            parity check of the observable. Each element of the list is a tuple
+            of (relative_qubit_position, relative_measurement_offset) or a
+            :class:`RelativeMeasurementData` instance. When a tuple is provided,
+            the first element is the position of the qubit relative to the local
+            coordinate system origin and the second element is the relative
+            measurement offset with respect to the most recent measurement
+            performed on the qubit.
+        observable_index: the index of the observable.
 
-    :return: A :class:`Observable` operation with the `cirq.VirtualTag` tag.
+    Returns:
+        A :class:`Observable` operation with the `cirq.VirtualTag` tag.
     """
     relative_measurements_data = [
         RelativeMeasurementData(*rm) if not isinstance(rm, RelativeMeasurementData) else rm

--- a/src/tqec/detectors/transformer.py
+++ b/src/tqec/detectors/transformer.py
@@ -109,9 +109,14 @@ def transform_to_stimcirq_compatible(
     - :class:`Observable`: converted to `stimcirq.CumulativeObservableAnnotation` with the correct
     relative keys computed.
 
-    :param circuit: The circuit to transform, which may contain tqec specific operations.
-    :param context: See `cirq.transformer` documentation.
-    :returns: A new circuit with the tqec specific operations transformed to stimcirq compatible operations.
+    Args:
+        circuit: The circuit to transform, which may contain tqec specific
+            operations.
+        context: See `cirq.transformer` documentation.
+
+    Returns:
+        A new circuit with the tqec specific operations transformed to stimcirq
+        compatible operations.
     """
     _annotation_safety_check(circuit)
     measurement_map = CircuitMeasurementMap(circuit)

--- a/src/tqec/display.py
+++ b/src/tqec/display.py
@@ -8,9 +8,10 @@ from tqec.templates.composed import ComposedTemplate
 def display_template(template: Template, *plaquette_indices: int) -> None:
     """Display a template instance with ASCII output.
 
-    :param template: the Template instance to display.
-    :param plaquette_indices: the plaquette indices that are forwarded to the
-        call to template.instantiate to get the actual template representation.
+    Args:
+        template: the Template instance to display.
+        *plaquette_indices: the plaquette indices that are forwarded to the call
+            to ``template.instantiate`` to get the actual template representation.
     """
     if len(plaquette_indices) == 0:
         plaquette_indices = tuple(range(1, template.expected_plaquettes_number + 1))
@@ -35,13 +36,15 @@ def display_templates_svg(
     the templates, it can be very slow for large templates and results in huge
     svg files.
 
-    :param templates: the TemplateOrchestrator instance to display.
-    :param write_svg_file: the path to the SVG file to write.
-    :param canvas_height: the height of the canvas in pixels to draw on.
-    :param plaquette_indices: the plaquette indices that are forwarded to the
-        call to template.instantiate to get the actual template representation.
+    Args:
+        templates: the TemplateOrchestrator instance to display.
+        write_svg_file: the path to the SVG file to write.
+        canvas_height: the height of the canvas in pixels to draw on.
+        *plaquette_indices: the plaquette indices that are forwarded to the call
+            to ``template.instantiate`` to get the actual template representation.
 
-    :return: the SVG string.
+    Returns:
+        the SVG string.
     """
     if len(plaquette_indices) == 0:
         plaquette_indices = tuple(range(1, templates.expected_plaquettes_number + 1))

--- a/src/tqec/display.py
+++ b/src/tqec/display.py
@@ -11,7 +11,7 @@ def display_template(template: Template, *plaquette_indices: int) -> None:
     Args:
         template: the Template instance to display.
         *plaquette_indices: the plaquette indices that are forwarded to the call
-            to ``template.instantiate`` to get the actual template representation.
+            to `template.instantiate` to get the actual template representation.
     """
     if len(plaquette_indices) == 0:
         plaquette_indices = tuple(range(1, template.expected_plaquettes_number + 1))
@@ -41,7 +41,7 @@ def display_templates_svg(
         write_svg_file: the path to the SVG file to write.
         canvas_height: the height of the canvas in pixels to draw on.
         *plaquette_indices: the plaquette indices that are forwarded to the call
-            to ``template.instantiate`` to get the actual template representation.
+            to `template.instantiate` to get the actual template representation.
 
     Returns:
         the SVG string.

--- a/src/tqec/generation/circuit.py
+++ b/src/tqec/generation/circuit.py
@@ -20,22 +20,27 @@ def generate_circuit(
 
     This function requires that a few pre-conditions on the inputs are met:
     1. the number of plaquettes provided should match the number of plaquettes required by
-       the provided template.
+    the provided template.
     2. all the provided plaquettes should be implemented on cirq.GridQubit instances **only**.
 
     If any of the above pre-conditions is not met, the inputs are considered invalid, in which
     case this function **might** raise an error.
 
-    :param template: spatial description of the quantum error correction experiment we want
-        to implement.
-    :param plaquettes: description of the computation that should happen at different time-slices
-        of the quantum error correction experiment (or at least part of it).
+    Args:
+        template: spatial description of the quantum error correction experiment
+            we want to implement.
+        plaquettes: description of the computation that should happen at
+            different time-slices of the quantum error correction experiment (or
+            at least part of it).
 
-    :returns: a cirq.Circuit instance implementing the (part of) quantum error correction experiment
-        represented by the provided inputs.
+    Returns:
+        a cirq.Circuit instance implementing the (part of) quantum error
+        correction experiment represented by the provided inputs.
 
-    :raises CannotUsePlaquetteWithDifferentShapes: if the provided Plaquette instance do not ALL
-        have the same shape. See https://github.com/QCHackers/tqec/issues/34 for more information.
+    Raises:
+        CannotUsePlaquetteWithDifferentShapes: if the provided Plaquette
+            instance do not ALL have the same shape. See
+            https://github.com/QCHackers/tqec/issues/34 for more information.
     """
     # Check that the user gave enough plaquettes.
     if len(plaquettes) != template.expected_plaquettes_number:

--- a/src/tqec/generation/topology.py
+++ b/src/tqec/generation/topology.py
@@ -25,8 +25,10 @@ def get_plaquette_starting_index(plaquette_size: int, plaquette_index: int) -> i
     This function also assumes that plaquettes are square-like shapes and share qubits
     on their edges.
 
-    :param plaquette_size: number of qubits required by the plaquette in the dimension
-        of interest (x or y).
-    :param plaquette_index: index of the plaquette we want to know the starting index of.
+    Args:
+        plaquette_size: number of qubits required by the plaquette in the
+            dimension of interest (x or y).
+        plaquette_index: index of the plaquette we want to know the starting
+            index of.
     """
     return plaquette_index * (plaquette_size - 1)

--- a/src/tqec/noise_models/after_clifford_depolarization.py
+++ b/src/tqec/noise_models/after_clifford_depolarization.py
@@ -12,8 +12,11 @@ def is_clifford(operation: cirq.Operation) -> bool:
     operations, which is the reason why this function will print a warning if the
     provided operation is considered "large" (3 qubits or more at the moment).
 
-    :param operation: the operation that will be checked.
-    :returns: True if the provided cirq.Operation instance is a Clifford operation,
+    Args:
+        operation: the operation that will be checked.
+
+    Returns:
+        True if the provided cirq.Operation instance is a Clifford operation,
         else False.
     """
     try:
@@ -42,7 +45,8 @@ class AfterCliffordDepolarizingNoise(BaseNoiseModel):
         this is different from applying `n` times a 1-qubit depolarizing noise to each
         of the involved qubits.
 
-        :param p: strength (probability of error) of the applied noise.
+        Args:
+            p: strength (probability of error) of the applied noise.
         """
         super().__init__(p)
 

--- a/src/tqec/noise_models/after_reset_flip.py
+++ b/src/tqec/noise_models/after_reset_flip.py
@@ -14,7 +14,8 @@ class AfterResetFlipNoise(BaseNoiseModel):
         circuit contains operations like the stim "MR" (Measurement and Reset)
         instruction, this noise channel will **not** add any noise.
 
-        :param p: strength (probability of error) of the applied noise.
+        Args:
+            operation: The operation to add noise on.
         """
         if isinstance(operation.gate, cirq.ResetChannel):
             return [

--- a/src/tqec/noise_models/base.py
+++ b/src/tqec/noise_models/base.py
@@ -5,7 +5,8 @@ class BaseNoiseModel(cirq.NoiseModel):
     def __init__(self, probability: float) -> None:
         """Base class for all `tqec` noise models
 
-        :param probability: strength of the noise described by the instance.
+        Args:
+            probability: strength of the noise described by the instance.
         """
         self._p = cirq.value.validate_probability(
             probability, "noise model probability"
@@ -24,11 +25,15 @@ class BaseNoiseModel(cirq.NoiseModel):
         This method does nothing if the provided operation is not a cirq.CircuitOperation instance
         and returns the same, unmodified, instance.
 
-        :param operation: a cirq.Operation instance that will be recursed in if and only if it is
-            a cirq.CircuitOperation instance.
-        :returns: a unmodified cirq.Operation instance if the provided operation is not an instance
-            of cirq.CircuitOperation. Else, the result of applying the noise model (subclass of this
-            class) calling this method on the cirq.Circuit instance wrapped in the operation.
+        Args:
+            operation: a cirq.Operation instance that will be recursed in if and
+                only if it is a cirq.CircuitOperation instance.
+
+        Returns:
+            An unmodified cirq.Operation instance if the provided operation is
+            not an instance of cirq.CircuitOperation. Else, the result of
+            applying the noise model (subclass of this class) calling this
+            method on the cirq.Circuit instance wrapped in the operation.
         """
         # If we have an instance of CircuitOperation, special handling should be performed to avoid
         # inserting a depolarizing channel as large as the circuit. In this specific case, we recurse

--- a/src/tqec/noise_models/before_measure_flip.py
+++ b/src/tqec/noise_models/before_measure_flip.py
@@ -5,13 +5,14 @@ from tqec.noise_models.base import BaseNoiseModel
 
 class BeforeMeasurementFlipNoise(BaseNoiseModel):
     def __init__(self, p: float):
-        """Applies a X flip noise before each measurement operation.
+        """Applies an X flip noise before each measurement operation.
 
         This noise model only works on cirq.MeasurementGate instances! If your quantum
         circuit contains operations like the stim "MR" (Measurement and Reset)
         instruction, this noise channel will **not** add any noise.
 
-        :param p: strength (probability of error) of the applied noise.
+        Args:
+            p: strength (probability of error) of the applied noise.
         """
         super().__init__(p)
 

--- a/src/tqec/noise_models/before_round_data_depolarization.py
+++ b/src/tqec/noise_models/before_round_data_depolarization.py
@@ -9,7 +9,8 @@ class BeforeRoundDataDepolarizationNoise(BaseNoiseModel):
 
         This noise model is currently not implemented.
 
-        :param p: strength (probability of error) of the applied noise.
+        Args:
+            p: strength (probability of error) of the applied noise.
         """
         super().__init__(p)
 

--- a/src/tqec/noise_models/idle_qubits.py
+++ b/src/tqec/noise_models/idle_qubits.py
@@ -13,7 +13,8 @@ class DepolarizingNoiseOnIdlingQubit(BaseNoiseModel):
         considered idle during this Moment and a depolarizing noise is added
         to account for this idle time.
 
-        :param p: strength (probability of error) of the applied noise.
+        Args:
+            p: strength (probability of error) of the applied noise.
         """
         super().__init__(p)
 

--- a/src/tqec/noise_models/multi_qubit_gates.py
+++ b/src/tqec/noise_models/multi_qubit_gates.py
@@ -12,7 +12,8 @@ class MultiQubitDepolarizingNoiseAfterMultiQubitGate(BaseNoiseModel):
         qubits `n > 1`, this is different from applying `n` times a 1-qubit
         depolarizing noise to each of the involved qubits.
 
-        :param p: strength (probability of error) of the applied noise.
+        Args:
+            p: strength (probability of error) of the applied noise.
         """
         super().__init__(p)
 

--- a/src/tqec/non_template_scaling/display_data.py
+++ b/src/tqec/non_template_scaling/display_data.py
@@ -17,7 +17,8 @@ def generate_coordinates(data):
     where each number is the length and the sign is the turning.
     this function constructs the coordinates for the positions
     and directions of each of these arrows. This prepares the
-    data to be drawn with matplotlib."""
+    data to be drawn with matplotlib.
+    """
 
     x_pos = []
     y_pos = []

--- a/src/tqec/plaquette/plaquette.py
+++ b/src/tqec/plaquette/plaquette.py
@@ -27,11 +27,11 @@ class Plaquette:
         By convention, the local plaquette coordinate system is composed of a X-axis pointing
         to the right and a Y-axis pointing down.
 
-        :param qubits: qubits used by the plaquette circuit, given in the local plaquette
-            coordinate system.
-        :param circuit: scheduled quantum circuit implementing the computation that the
-            plaquette should represent.
-
+        Args:
+            qubits: qubits used by the plaquette circuit, given in the local
+                plaquette coordinate system.
+            circuit: scheduled quantum circuit implementing the computation that
+                the plaquette should represent.
         """
         plaquette_qubits = {qubit.to_grid_qubit() for qubit in qubits}
         circuit_qubits = set(circuit.raw_circuit.all_qubits())
@@ -75,8 +75,9 @@ class SquarePlaquette(Plaquette):
         gates, for example in surface codes. It is a **qubit** ordering and has **no
         relation** with a temporal ordering.
 
-        :param circuit: scheduled quantum circuit implementing the computation that the
-            plaquette should represent.
+        Args:
+            circuit: scheduled quantum circuit implementing the computation that
+                the plaquette should represent.
         """
         super().__init__(self.get_data_qubits() + self.get_syndrome_qubits(), circuit)
 
@@ -128,20 +129,21 @@ class RoundedPlaquette(Plaquette):
         | 1     2 |
         |---------|
         ```
-        as `3` (the index of the bottom-right qubit in the initial ordering) is the 
+        as `3` (the index of the bottom-right qubit in the initial ordering) is the
         lowest index (i.e., the number `1`) and `4` follows.
 
-        Sub-classes of this class should take that into account to apply operations
+        Subclasses of this class should take that into account to apply operations
         on the correct qubits.
         This ordering is not to be confused with the temporal ordering of multi-qubit
         gates, for example in surface codes. It is a **qubit** ordering and has **no
         relation** with a temporal ordering.
 
-        :param circuit: scheduled quantum circuit implementing the computation that the
-            plaquette should represent.
-        :param orientation: side at which the plaquette is "pointing at". An orientation
-            of PlaquetteOrientation.UP will generate a plaquette with its rounded side
-            pointing up.
+        Args:
+            circuit: scheduled quantum circuit implementing the computation that
+                the plaquette should represent.
+            orientation: side at which the plaquette is "pointing at". An
+                orientation of PlaquetteOrientation.UP will generate a plaquette
+                with its rounded side pointing up.
         """
         super().__init__(
             RoundedPlaquette.get_data_qubits(orientation)

--- a/src/tqec/plaquette/schedule.py
+++ b/src/tqec/plaquette/schedule.py
@@ -62,13 +62,15 @@ class ScheduledCircuit:
         its interfaces insert a schedule of VIRTUAL_MOMENT_SCHEDULE when the Moment instance
         is virtual.
 
-        :param circuit: the instance of Circuit that is scheduled.
-        :param schedule: a sorted list of time slices indices. The list should contain
-            as much indices as there are non-virtual moments in the provided Circuit
-            instance. If the list is None, it default to
-            `list(range(number_of_non_virtual_moments))`.
+        Args:
+            circuit: the instance of Circuit that is scheduled.
+            schedule: a sorted list of time slices indices. The list should
+                contain as many indices as there are non-virtual moments in the
+                provided Circuit instance. If the list is None, it default to
+                `list(range(number_of_non_virtual_moments))`.
 
-        :raises ScheduleError: if the provided schedule is invalid.
+        Raises:
+            ScheduleError: if the provided schedule is invalid.
         """
         self._is_non_virtual_moment_list: list[bool] = [
             not ScheduledCircuit._is_virtual_moment(moment)
@@ -88,16 +90,21 @@ class ScheduledCircuit:
     def _check_input_validity(circuit: cirq.Circuit, schedule: list[int]) -> None:
         """Asserts that the given inputs are valid to construct a ScheduledCircuit instance.
 
-        :param schedule: the schedule to check.
+        Args:
+            schedule: the schedule to check.
 
-        :raises ScheduleWithNonIntegerEntries: if the given schedule has a non-integer entry.
-        :raises ScheduleNotSorted: if the given schedule is not a sorted list.
-        :raises ScheduleEntryTooLow: if the given schedule has an entry that would lead to incorrect
-            scheduling.
-        :raises ScheduleCannotBeAppliedToCircuit: if the given schedule cannot be applied to the
-            provided cirq.Circuit instance, for example if the number of entries in the schedule and
-            the number of non-virtual moments in the circuit are not equal.
-        :raises QubitTypeError: if any of the circuit qubit is not a cirq.GridQubit instance.
+        Raises:
+            ScheduleWithNonIntegerEntries: if the given schedule has a non-
+                integer entry.
+            ScheduleNotSorted: if the given schedule is not a sorted list.
+            ScheduleEntryTooLow: if the given schedule has an entry that would
+                lead to incorrect scheduling.
+            ScheduleCannotBeAppliedToCircuit: if the given schedule cannot be
+                applied to the provided cirq.Circuit instance, for example if
+                the number of entries in the schedule and the number of non-
+                virtual moments in the circuit are not equal.
+            QubitTypeError: if any of the circuit qubit is not a cirq.GridQubit
+                instance.
         """
         # Check that all the qubits in the cirq.Circuit instance are instances of cirq.GridQubit.
         for q in circuit.all_qubits():
@@ -155,8 +162,9 @@ class ScheduledCircuit:
         This construction method basically auto-schedules single-qubit gates from
         the schedule of multi-qubit ones.
 
-        :raises ScheduleError: if the provided schedule is invalid or if the auto-scheduling is
-            impossible.
+        Raises:
+            ScheduleError: if the provided schedule is invalid or if the auto-
+                scheduling is impossible.
         """
         ScheduledCircuit._check_input_validity(circuit, multi_qubit_moment_schedule)
 
@@ -237,7 +245,8 @@ class ScheduledCircuit:
     def mappable_qubits(self) -> frozenset[cirq.GridQubit]:
         """Return the set of qubits involved in the circuit that can be mapped, which is
         the union of the qubits of all the operations performed on and the origin of all
-        the detectors."""
+        the detectors.
+        """
         operation_qubits = set(self.raw_circuit.all_qubits())
         detector_origins = set(detector.origin for detector in self.detectors)
         return frozenset(operation_qubits.union(detector_origins))
@@ -252,12 +261,14 @@ class ScheduledCircuit:
         changing measurements key by re-creating the correct measurements and
         re-creating Detector operation correctly.
 
-        :param qubit_map: the map used to modify the qubits.
-        :param inplace: if True, perform the modification in place and return
-            self. Else, perform the modification in a copy and return the copy.
+        Args:
+            qubit_map: the map used to modify the qubits.
+            inplace: if True, perform the modification in place and return self.
+                Else, perform the modification in a copy and return the copy.
 
-        :returns: a modified instance of ScheduledCircuit (a copy if inplace is
-            True, else self).
+        Returns:
+            a modified instance of ScheduledCircuit (a copy if inplace is True,
+            else self).
         """
 
         def remap_qubits(op: cirq.Operation) -> cirq.Operation:
@@ -346,7 +357,8 @@ class ScheduledCircuits:
         ScheduledCircuit, and implement a few other accessor methods to help with the
         task of merging multiple ScheduledCircuit together.
 
-        :param circuits: the instances that should be managed.
+        Args:
+            circuits: the instances that should be managed.
         """
         self._circuits = circuits
         self._iterators = [circuit.scheduled_moments for circuit in self._circuits]
@@ -370,7 +382,8 @@ class ScheduledCircuits:
     def _pop_scheduled_moment(self, index: int) -> tuple[cirq.Moment, int]:
         """Recover and mark as collected the pending moment for the instance at the given index.
 
-        :raises AssertionError: if not self.has_pending_operation(index).
+        Raises:
+            AssertionError: if not self.has_pending_operation(index).
         """
         ret = self._current_moments[index]
         if ret is None:
@@ -393,7 +406,9 @@ class ScheduledCircuits:
         ScheduledCircuit.VIRTUAL_MOMENT_SCHEDULE, virtual Moment instances are always scheduled first
         when encountered.
 
-        :returns: a list of Moment instances that should be added next to the QEC circuit.
+        Returns:
+            a list of Moment instances that should be added next to the QEC
+            circuit.
         """
         circuit_indices_organised_by_schedule: dict[int, list[int]] = dict()
         for circuit_index in range(self.number_of_circuits):
@@ -425,9 +440,10 @@ def remove_duplicate_operations(
     If two operations in the provided list are considered equal **AND** are
     mergeable, this method will one of them.
 
-    :returns: a list containing a copy of the cirq.Operation instances from
-        the given operations, without the mergeable tag, and with mergeable
-        duplicates removed from the list.
+    Returns:
+        a list containing a copy of the cirq.Operation instances from the given
+        operations, without the mergeable tag, and with mergeable duplicates
+        removed from the list.
     """
     # Import needed here to resolve at runtime and avoid circular import.
     from tqec.plaquette.plaquette import Plaquette
@@ -456,8 +472,8 @@ def merge_scheduled_circuits(circuits: list[ScheduledCircuit]) -> cirq.Circuit:
     respecting their schedules, into a unique cirq.Circuit instance that will
     then be returned to the caller.
 
-    :returns: a circuit representing the merged scheduled circuits given as
-        input.
+    Returns:
+        a circuit representing the merged scheduled circuits given as input.
     """
     scheduled_circuits = ScheduledCircuits(circuits)
     all_moments: list[cirq.Moment] = list()

--- a/src/tqec/templates/base.py
+++ b/src/tqec/templates/base.py
@@ -17,8 +17,9 @@ def _json_encoding_default(obj) -> str | dict | None:
     way to translate the enumerations used by some templates to JSON
     data.
 
-    :raises TypeError: if an instance of a unimplemented type is
-        provided as parameter.
+    Raises:
+        TypeError: if an instance of a unimplemented type is provided as
+            parameter.
     """
     if isinstance(obj, CornerPositionEnum):
         return f"{obj.name}"
@@ -39,10 +40,15 @@ class JSONEncodable(ABC):
     def to_json(self, **kwargs) -> str:
         """Returns a JSON representation of the instance.
 
-        :param kwargs: keyword arguments forwarded to the json.dumps function. The "default"
-            keyword argument should NOT be present.
-        :returns: the JSON representation of the instance.
-        :raises DefaultKeyInKwargs: if the "default" key is present in kwargs.
+        Args:
+            **kwargs: keyword arguments forwarded to the json.dumps function.
+                The "default" keyword argument should NOT be present.
+
+        Returns:
+            the JSON representation of the instance.
+
+        Raises:
+            DefaultKeyInKwargs: if the "default" key is present in kwargs.
         """
         if "default" in kwargs:
             raise TQECException(
@@ -63,8 +69,11 @@ class Template(JSONEncodable):
         This class is the base of all templates and provide the necessary interface
         that all templates should implement to be usable by the library.
 
-        :param default_x_increment: default increment in the x direction between two plaquettes.
-        :param default_y_increment: default increment in the y direction between two plaquettes.
+        Args:
+            default_x_increment: default increment in the x direction between
+                two plaquettes.
+            default_y_increment: default increment in the y direction between
+                two plaquettes.
         """
         super().__init__()
         self._default_increments = Displacement(
@@ -75,10 +84,13 @@ class Template(JSONEncodable):
     def instantiate(self, *plaquette_indices: int) -> numpy.ndarray:
         """Generate the numpy array representing the template.
 
-        :param plaquette_indices: the plaquette indices that will be forwarded to the
-            underlying Shape instance's instantiate method.
-        :returns: a numpy array with the given plaquette indices arranged according
-            to the underlying shape of the template.
+        Args:
+            *plaquette_indices: the plaquette indices that will be forwarded to
+                the underlying Shape instance's instantiate method.
+
+        Returns:
+            a numpy array with the given plaquette indices arranged according to
+            the underlying shape of the template.
         """
         pass
 
@@ -94,8 +106,11 @@ class Template(JSONEncodable):
         Note that this function scales to INLINE, so the instance on which it is called is
         modified in-place AND returned.
 
-        :param k: the new scale of the template.
-        :returns: self, once scaled.
+        Args:
+            k: the new scale of the template.
+
+        Returns:
+            self, once scaled.
         """
         pass
 
@@ -110,7 +125,8 @@ class Template(JSONEncodable):
         - the numpy-like shape, that is represented as 2 integers encoding the sizes
           of the returned numpy array in both dimensions.
 
-        :returns: the numpy-like shape of the template.
+        Returns:
+            the numpy-like shape of the template.
         """
         pass
 
@@ -136,14 +152,16 @@ class Template(JSONEncodable):
     def expected_plaquettes_number(self) -> int:
         """Returns the number of plaquettes expected from the `instantiate` method.
 
-        :returns: the number of plaquettes expected from the `instantiate` method.
+        Returns:
+            the number of plaquettes expected from the `instantiate` method.
         """
         pass
 
     def get_increments(self) -> Displacement:
         """Get the default increments of the template.
 
-        :returns: a displacement of the default increments in the x and y directions.
+        Returns:
+            a displacement of the default increments in the x and y directions.
         """
         return self._default_increments
 
@@ -167,9 +185,12 @@ class AtomicTemplate(Template):
         For example a default_x_increment of 2 means that two 2x2 plaquettes will share
         a common edge.
 
-        :param shape: the underlying template shape.
-        :param default_x_increment: default increment in the x direction between two plaquettes.
-        :param default_y_increment: default increment in the y direction between two plaquettes.
+        Args:
+            shape: the underlying template shape.
+            default_x_increment: default increment in the x direction between
+                two plaquettes.
+            default_y_increment: default increment in the y direction between
+                two plaquettes.
         """
         super().__init__(default_x_increment, default_y_increment)
         self._shape_instance = shape
@@ -177,10 +198,13 @@ class AtomicTemplate(Template):
     def instantiate(self, *plaquette_indices: int) -> numpy.ndarray:
         """Generate the numpy array representing the template.
 
-        :param plaquette_indices: the plaquette indices that will be forwarded to the
-            underlying Shape instance's instantiate method.
-        :returns: a numpy array with the given plaquette indices arranged according
-            to the underlying shape of the template.
+        Args:
+            *plaquette_indices: the plaquette indices that will be forwarded to
+                the underlying Shape instance's instantiate method.
+
+        Returns:
+            a numpy array with the given plaquette indices arranged according to
+            the underlying shape of the template.
         """
         return self._shape_instance.instantiate(*plaquette_indices)
 
@@ -194,7 +218,8 @@ class AtomicTemplate(Template):
         - the numpy-like shape, that is represented as 2 integers encoding the sizes
           of the returned numpy array in both dimensions.
 
-        :returns: the numpy-like shape of the template.
+        Returns:
+            the numpy-like shape of the template.
         """
         return self._shape_instance.shape
 
@@ -210,8 +235,11 @@ class AtomicTemplate(Template):
         Note that this function scales to INLINE, so the instance on which it is called is
         modified in-place AND returned.
 
-        :param k: the new scale of the template.
-        :returns: self, once scaled.
+        Args:
+            k: the new scale of the template.
+
+        Returns:
+            self, once scaled.
         """
         pass
 
@@ -236,14 +264,16 @@ class AtomicTemplate(Template):
     def expected_plaquettes_number(self) -> int:
         """Returns the number of plaquettes expected from the `instantiate` method.
 
-        :returns: the number of plaquettes expected from the `instantiate` method.
+        Returns:
+            the number of plaquettes expected from the `instantiate` method.
         """
         return self._shape_instance.expected_plaquettes_number
 
 
 @dataclass
 class TemplateWithIndices:
-    """A wrapper around a Template instance and the indices representing the plaquettes it should be instantiated with."""
+    """A wrapper around a Template instance and the indices representing the plaquettes
+    it should be instantiated with."""
 
     template: Template
     indices: list[int]

--- a/src/tqec/templates/base.py
+++ b/src/tqec/templates/base.py
@@ -48,7 +48,7 @@ class JSONEncodable(ABC):
             the JSON representation of the instance.
 
         Raises:
-            DefaultKeyInKwargs: if the "default" key is present in kwargs.
+            TQECException: if the "default" key is present in kwargs.
         """
         if "default" in kwargs:
             raise TQECException(

--- a/src/tqec/templates/composed.py
+++ b/src/tqec/templates/composed.py
@@ -31,12 +31,14 @@ def get_corner_position(
     >>> get_corner_position(Position(0, 0), CornerPositionEnum.LOWER_RIGHT, Shape2D(2, 2), CornerPositionEnum.UPPER_LEFT)
     Position(x=-2, y=-2)
 
+    Args:
+        position: position of the "anchor" corner.
+        position_corner: corner which position is given as first argument.
+        shape: 2-dimensional shape of the considerer template.
+        expected_corner: the corner we want to compute the position of.
 
-    :param position: position of the "anchor" corner.
-    :param position_corner: corner which position is given as first argument.
-    :param shape: 2-dimensional shape of the considerer template.
-    :param expected_corner: the corner we want to compute the position of.
-    :returns: the position of the expected_corner of a template of the given shape,
+    Returns:
+        the position of the expected_corner of a template of the given shape,
         knowing that the corner position_corner is at the given position.
     """
     transformation: tuple[int, int] = (
@@ -89,9 +91,13 @@ class ComposedTemplate(Template):
           |
           V
 
-        :param templates: a list of templates forwarded to the add_templates method
-            at the end of instance initialisation.
-        :raises ValueError: if the templates provided have different default increments.
+        Args:
+            templates: a list of templates forwarded to the add_templates method
+                at the end of instance initialisation.
+
+        Raises:
+            ValueError: if the templates provided have different default
+                increments.
         """
         self._templates: list[Template] = []
         self._relative_position_graph = nx.DiGraph()
@@ -114,9 +120,16 @@ class ComposedTemplate(Template):
     ) -> int:
         """Add the provided template to the data structure.
 
-        :param template_to_insert: the template to insert, along with the indices of the
-        :raises ValueError: if the template to insert has different default increments than
-        :returns: the index of the template in the list of templates.
+        Args:
+            template_to_insert: the template to insert, along with the indices
+                of the
+
+        Returns:
+            the index of the template in the list of templates.
+
+        Raises:
+            ValueError: if the template to insert has different default
+                increments than
         """
         if len(self._templates) == 0:
             self._default_increments = template_to_insert.template.get_increments()
@@ -155,14 +168,19 @@ class ComposedTemplate(Template):
         This method is kept in the interface because the interface it provides is simpler
         to use and read than add_corner_relation.
 
-        :param template_id_to_position: index of the template that should be positionned relatively
-            to the provided anchor.
-        :param relative_position: the relative position of the template provided as first parameter
-            with respect to the anchor provided as third parameter. Can be any of LEFT_OF, RIGHT_OF,
-            BELOW_OF and ABOVE_OF.
-        :param anchor_id: index of the anchor template, i.e., the template with respect to which the
-            template provided in first parameter will be positioned.
-        :returns: self, to be able to chain calls to this method.
+        Args:
+            template_id_to_position: index of the template that should be
+                positionned relatively to the provided anchor.
+            relative_position: the relative position of the template provided as
+                first parameter with respect to the anchor provided as third
+                parameter. Can be any of LEFT_OF, RIGHT_OF, BELOW_OF and
+                ABOVE_OF.
+            anchor_id: index of the anchor template, i.e., the template with
+                respect to which the template provided in first parameter will
+                be positioned.
+
+        Returns:
+            self, to be able to chain calls to this method.
         """
         self._check_template_id(template_id_to_position)
         self._check_template_id(anchor_id)
@@ -200,13 +218,17 @@ class ComposedTemplate(Template):
     ) -> "ComposedTemplate":
         """Add a relative positioning between two templates.
 
-        :param template_id_to_position_corner: a tuple containing the index of the template that
-            should be positionned relatively to the provided anchor and the corner that should be
-            considered.
-        :param anchor_id_corner: a tuple containing the index of the (anchor) template that
-            should be used to position the template instance provided in the first parameter,
-            and the corner that should be considered.
-        :returns: self, to be able to chain calls to this method.
+        Args:
+            template_id_to_position_corner: a tuple containing the index of the
+                template that should be positionned relatively to the provided
+                anchor and the corner that should be considered.
+            anchor_id_corner: a tuple containing the index of the (anchor)
+                template that should be used to position the template instance
+                provided in the first parameter, and the corner that should be
+                considered.
+
+        Returns:
+            self, to be able to chain calls to this method.
         """
         anchor_id, anchor_corner = anchor_id_corner
         template_id, template_corner = template_id_to_position_corner
@@ -239,8 +261,9 @@ class ComposedTemplate(Template):
         This means in particular that this method can return positions with negative
         coordinates.
 
-        :returns: a mapping between templates indices and their upper-left corner absolute
-            position.
+        Returns:
+            a mapping between templates indices and their upper-left corner
+            absolute position.
         """
         ul_positions: dict[int, Position] = {0: Position(0, 0)}
         src: int
@@ -287,10 +310,14 @@ class ComposedTemplate(Template):
     ) -> tuple[Position, Position]:
         """Get the bounding box containing all the templates from their upper-left corner position.
 
-        :param ul_positions: a mapping between templates indices and their upper-left corner absolute
-            position.
-        :returns: a tuple (upper-left position, bottom-right position) representing the bounding box.
-            Coordinates in each positions are not guaranteed to be positive.
+        Args:
+            ul_positions: a mapping between templates indices and their upper-left
+            corner absolute position.
+
+        Returns:
+            a tuple (upper-left position, bottom-right position) representing
+            the bounding box. Coordinates in each positions are not guaranteed
+            to be positive.
         """
         # ul: upper-left
         # br: bottom-right
@@ -307,8 +334,9 @@ class ComposedTemplate(Template):
     def _get_shape_from_bounding_box(self, ul: Position, br: Position) -> Shape2D:
         """Get the shape of the represented code from the bounding box.
 
-        :param ul: upper-left corner position of the bounding box.
-        :param br: bottom-right corner position of the bounding box.
+        Args:
+            ul: upper-left corner position of the bounding box.
+            br: bottom-right corner position of the bounding box.
         """
         # ul: upper-left
         # br: bottom-right
@@ -371,10 +399,13 @@ class ComposedTemplate(Template):
 
         The current implementation does not expect such a plaquette anymore.
 
-        :param plaquette_indices: the plaquette indices that will be used to
-            instantiate the different orchestrated templates.
-        :returns: a numpy array with the given plaquette indices arranged according
-            to the underlying shape of the template.
+        Args:
+            *plaquette_indices: the plaquette indices that will be used to
+                instantiate the different orchestrated templates.
+
+        Returns:
+            a numpy array with the given plaquette indices arranged according to
+            the underlying shape of the template.
         """
         if 0 in plaquette_indices:
             raise TQECException(
@@ -391,8 +422,9 @@ class ComposedTemplate(Template):
     def default_increments(self) -> Displacement:
         """Get the increments between plaquettes of the template.
 
-        :returns: a Displacement(x increment, y increment) representing the increments between
-            plaquettes of the template.
+        Returns:
+            a Displacement(x increment, y increment) representing the increments
+            between plaquettes of the template.
         """
         return self._default_increments
 
@@ -407,8 +439,11 @@ class ComposedTemplate(Template):
         Note that this function scales to INLINE, so the instance on which it is called is
         modified in-place AND returned.
 
-        :param k: the new scale of the component templates.
-        :returns: self, once scaled.
+        Args:
+            k: the new scale of the component templates.
+
+        Returns:
+            self, once scaled.
         """
         for t in self._templates:
             t.scale_to(k)

--- a/src/tqec/templates/constructions/corner.py
+++ b/src/tqec/templates/constructions/corner.py
@@ -39,7 +39,8 @@ class ScalableCorner(ComposedTemplate):
         .  . 12  . 12  . 12  . 12  . 12  .
         ```
 
-        :param k: scale of the initial error-corrected qubit.
+        Args:
+            k: scale of the initial error-corrected qubit.
         """
         dim = 2 * k
         _templates = [

--- a/src/tqec/templates/constructions/qubit.py
+++ b/src/tqec/templates/constructions/qubit.py
@@ -23,7 +23,8 @@ class ScalableQubitSquare(ComposedTemplate):
         .  6  .  6  .  .
         ```
 
-        :param k: scale of the error-corrected qubit.
+        Args:
+            k: scale of the error-corrected qubit.
         """
         dim = 2 * k
         _templates = [
@@ -65,11 +66,12 @@ class ScalableQubitRectangle(ComposedTemplate):
         .  6  .  6  .  6  .  .
         ```
 
-        :param k_width: half the width of the qubit.
-        :param k_height: half the height of the qubit.
-        :param scale_width: whether to scale the width or height. If None, the dimension
-            with the larger value will be scaled. If both dimensions are equal, the width
-            will be scaled by default.
+        Args:
+            k_width: half the width of the qubit.
+            k_height: half the height of the qubit.
+            scale_width: whether to scale the width or height. If None, the
+                dimension with the larger value will be scaled. If both
+                dimensions are equal, the width will be scaled by default.
         """
         width, height = 2 * k_width, 2 * k_height
         _templates = [

--- a/src/tqec/templates/fixed/base.py
+++ b/src/tqec/templates/fixed/base.py
@@ -16,8 +16,9 @@ class FixedRaw(FixedTemplate):
     def __init__(self, plaquette_template: list[list[int]]) -> None:
         """Create an instance of FixedRaw.
 
-        :param plaquette_template: a 2-dimensional array of indices starting from 0.
-            The indices in this array will be used to **index** the plaquette_indices
-            list provided to the instantiate method.
+        Args:
+            plaquette_template: a 2-dimensional array of indices starting from
+                0. The indices in this array will be used to **index** the
+                plaquette_indices list provided to the instantiate method.
         """
         super().__init__(RawRectangle(plaquette_template))

--- a/src/tqec/templates/scalable/rectangle.py
+++ b/src/tqec/templates/scalable/rectangle.py
@@ -15,12 +15,16 @@ class ScalableRectangle(ScalableTemplate):
 
         A scalable rectangle can only scale its width **or** height, but not both.
 
-        :param width: width of the rectangle.
-        :param height: height of the rectangle.
-        :param scale_width: whether to scale the width or height. If None, the dimension
-            with the even value or the larger value will be scaled. If both dimensions
-            are even and equal, the width will be scaled by default.
-        :raises DimensionNotEven: if both width and height are odd numbers.
+        Args:
+            width: width of the rectangle.
+            height: height of the rectangle.
+            scale_width: whether to scale the width or height. If None, the
+                dimension with the even value or the larger value will be
+                scaled. If both dimensions are even and equal, the width will be
+                scaled by default.
+
+        Raises:
+            DimensionNotEven: if both width and height are odd numbers.
         """
         if width % 2 != 0 and height % 2 != 0:
             raise TQECException(

--- a/src/tqec/templates/shapes/base.py
+++ b/src/tqec/templates/shapes/base.py
@@ -35,7 +35,8 @@ class BaseShape(ABC):
     def expected_plaquettes_number(self) -> int:
         """Returns the number of plaquettes expected from the `instantiate` method.
 
-        :returns: the number of plaquettes expected from the `instantiate` method.
+        Returns:
+            the number of plaquettes expected from the `instantiate` method.
         """
         pass
 

--- a/src/tqec/templates/shapes/rectangle.py
+++ b/src/tqec/templates/shapes/rectangle.py
@@ -46,7 +46,8 @@ class Rectangle(BaseShape):
     def expected_plaquettes_number(self) -> int:
         """Returns the number of plaquettes expected from the `instantiate` method.
 
-        :returns: the number of plaquettes expected from the `instantiate` method.
+        Returns:
+            the number of plaquettes expected from the `instantiate` method.
         """
         return 2
 
@@ -86,6 +87,7 @@ class RawRectangle(Rectangle):
     def expected_plaquettes_number(self) -> int:
         """Returns the number of plaquettes expected from the `instantiate` method.
 
-        :returns: the number of plaquettes expected from the `instantiate` method.
+        Returns:
+            the number of plaquettes expected from the `instantiate` method.
         """
         return max(max(line) for line in self._indices) + 1

--- a/src/tqec/templates/shapes/square.py
+++ b/src/tqec/templates/shapes/square.py
@@ -88,6 +88,7 @@ class AlternatingCornerSquare(AlternatingSquare):
     def expected_plaquettes_number(self) -> int:
         """Returns the number of plaquettes expected from the `instantiate` method.
 
-        :returns: the number of plaquettes expected from the `instantiate` method.
+        Returns:
+            the number of plaquettes expected from the `instantiate` method.
         """
         return 5


### PR DESCRIPTION
Closes #118 

This PR changes the docstring style of all the functions and classes from rest to google style.

Initially, I used [pyment](https://github.com/dadadel/pyment) for this, however, it turns out `pyment` cannot handle the multi-line argument descriptions correctly[^1]. Then I turn to a less well-known package [docconvert](https://github.com/cbillingham/docconvert) and it worked out quite well.

I have checked the auto-converted files with `diff` preview in my IDE, but slight errors might still exist. The conversion process can be reproduced following the procedure below:

1. Install the `docconvert` python package: 
  ```shell
  pip install docconvert
  ```
2. Create the configuration file `docconvert.json` under the directory of your `tqec` project:
  ```json
  {
      "input_style": "rest",
      "output_style": "google",
      "accepted_shebangs": [
          "python"
      ],
      "output": {
          "first_line": true,
          "replace_quotes": "\"\"\"",
          "standard_indent": "    ",
          "tab_length": 4,
          "realign": true,
          "max_line_length": 80,
          "use_optional": false,
          "remove_type_back_ticks": "true",
          "use_types": false,
          "separate_keywords": false
      }
  }
  ```
3. Run `docconvert` from the command line:
  ```shell
  docconvert --threads 4 --in-place --config docconvert.json src/tqec
  ```

[^1]: https://github.com/dadadel/pyment/issues/76