### PR TITLE
Fix some exception types in docstring

### DIFF
--- a/src/tqec/detectors/measurement_map.py
+++ b/src/tqec/detectors/measurement_map.py
@@ -65,8 +65,7 @@ class CircuitMeasurementMap:
             current_moment_index, or None if the searched offset does not exist.
 
         Raises:
-            PositiveMeasurementOffsetError: if the provided measurement_offset
-                value is positive.
+            TQECException: if the provided measurement_offset value is positive.
         """
         if measurement_offset >= 0:
             raise TQECException(
@@ -133,8 +132,7 @@ class CircuitMeasurementMap:
               be useful for the external caller.
 
         Raises:
-            MeasurementAppliedOnMultipleQubits: if the provided
-                cirq.AbstractCircuit instance contains measurements applied on
+            TQECException: if the provided cirq.AbstractCircuit instance contains measurements applied on
                 several qubits at the same time.
         """
         global_measurement_indices: list[dict[cirq.Qid, int]] = []
@@ -172,6 +170,9 @@ def compute_global_measurements_lookback_offsets(
 
     Returns:
         the computed list of global measurements lookback offsets.
+
+    Raises:
+        TQECException: if the global measurement offset computation fails.
     """
     global_measurements_lookback_offsets = []
     origin = relative_measurements_record.origin

--- a/src/tqec/detectors/operation.py
+++ b/src/tqec/detectors/operation.py
@@ -31,7 +31,8 @@ class ShiftCoords(cirq.Operation):
         with the correct tags. Otherwise, you might need to manually tag the operation with the
         `cirq.VirtualTag` and the `STIM_TAG`.
 
-        :param shifts: How much to shift each coordinate.
+        Args:
+            shifts: How much to shift each coordinate.
         """
         self._shifts = shifts
 

--- a/src/tqec/detectors/operation.py
+++ b/src/tqec/detectors/operation.py
@@ -32,7 +32,7 @@ class ShiftCoords(cirq.Operation):
         `cirq.VirtualTag` and the `STIM_TAG`.
 
         Args:
-            shifts: How much to shift each coordinate.
+            *shifts: How much to shift each coordinate.
         """
         self._shifts = shifts
 

--- a/src/tqec/exceptions.py
+++ b/src/tqec/exceptions.py
@@ -1,9 +1,2 @@
 class TQECException(Exception):
     pass
-
-
-class QubitTypeException(TQECException):
-    def __init__(self, expected_qubit_type: type, found_qubit_type: type) -> None:
-        super().__init__(
-            f"Excepted only instances of {expected_qubit_type.__name__} but found an instance of {found_qubit_type.__name__}."
-        )

--- a/src/tqec/generation/circuit.py
+++ b/src/tqec/generation/circuit.py
@@ -38,9 +38,8 @@ def generate_circuit(
         correction experiment represented by the provided inputs.
 
     Raises:
-        CannotUsePlaquetteWithDifferentShapes: if the provided Plaquette
-            instance do not ALL have the same shape. See
-            https://github.com/QCHackers/tqec/issues/34 for more information.
+        TQECException: if the provided plaquettes do not match the expected
+            number of plaquettes for the given template.
     """
     # Check that the user gave enough plaquettes.
     if len(plaquettes) != template.expected_plaquettes_number:

--- a/src/tqec/plaquette/plaquette.py
+++ b/src/tqec/plaquette/plaquette.py
@@ -32,6 +32,10 @@ class Plaquette:
                 plaquette coordinate system.
             circuit: scheduled quantum circuit implementing the computation that
                 the plaquette should represent.
+
+        Raises:
+            TQECException: if the provided circuit uses qubits not in the list of
+                PlaquetteQubit.
         """
         plaquette_qubits = {qubit.to_grid_qubit() for qubit in qubits}
         circuit_qubits = set(circuit.raw_circuit.all_qubits())
@@ -167,7 +171,8 @@ class RoundedPlaquette(Plaquette):
         the example from the class docstring, an orientation of PlaquetteOrientation.UP
         will return the qubits indexed 3 and 4 (or 2 and 3 in a 0-based indexing).
 
-        :param orientation: plaquette orientation
+        Args:
+            orientation: plaquette orientation
         """
         data_indices: tuple[int, int]
         if orientation == PlaquetteOrientation.RIGHT:

--- a/src/tqec/plaquette/schedule.py
+++ b/src/tqec/plaquette/schedule.py
@@ -5,7 +5,7 @@ from copy import deepcopy
 import cirq
 
 from tqec.detectors.operation import Detector, make_detector
-from tqec.exceptions import QubitTypeException, TQECException
+from tqec.exceptions import TQECException
 
 
 class ScheduleException(TQECException):
@@ -94,22 +94,23 @@ class ScheduledCircuit:
             schedule: the schedule to check.
 
         Raises:
-            ScheduleWithNonIntegerEntries: if the given schedule has a non-
-                integer entry.
+            ScheduleWithNonIntegerEntries: if the given schedule has a non-integer entry.
             ScheduleNotSorted: if the given schedule is not a sorted list.
             ScheduleEntryTooLow: if the given schedule has an entry that would
                 lead to incorrect scheduling.
             ScheduleCannotBeAppliedToCircuit: if the given schedule cannot be
                 applied to the provided cirq.Circuit instance, for example if
-                the number of entries in the schedule and the number of non-
-                virtual moments in the circuit are not equal.
-            QubitTypeError: if any of the circuit qubit is not a cirq.GridQubit
+                the number of entries in the schedule and the number of non-virtual moments
+                in the circuit are not equal.
+            TQECException: if any of the circuit qubit is not a cirq.GridQubit
                 instance.
         """
         # Check that all the qubits in the cirq.Circuit instance are instances of cirq.GridQubit.
         for q in circuit.all_qubits():
             if not isinstance(q, cirq.GridQubit):
-                raise QubitTypeException(cirq.GridQubit, type(q))
+                raise TQECException(
+                    f"Excepted only instances of 'cirq.GridQubit', "
+                    f"but found an instance of {q.__class__.__name__}.")
 
         # Check that all entries in the provided schedule are integers.
         for entry in schedule:


### PR DESCRIPTION
I noticed several exception types in the docstring that weren't updated properly after the merge of #73. This pull request primarily addresses those types. Additionally, I identified one argument docstring that wasn't properly converted in #112, and I fixed that as well.