### PR TITLE
Add support for Python 3.9

### DIFF
--- a/src/tqec/detectors/measurement_map.py
+++ b/src/tqec/detectors/measurement_map.py
@@ -1,7 +1,8 @@
-import cirq
+from __future__ import annotations
 
-from tqec.exceptions import TQECException
+import cirq
 from tqec.detectors.operation import RelativeMeasurementsRecord
+from tqec.exceptions import TQECException
 
 
 def flatten(obj: cirq.Moment | cirq.AbstractCircuit) -> cirq.Circuit:
@@ -142,7 +143,9 @@ class CircuitMeasurementMap:
             for op in moment.operations:
                 if isinstance(op.gate, cirq.MeasurementGate):
                     if len(op.qubits) > 1:
-                        raise TQECException(f"Found a measurement applied on multiple qubits ({op.qubits}).")
+                        raise TQECException(
+                            f"Found a measurement applied on multiple qubits ({op.qubits})."
+                        )
                     qubit: cirq.Qid = op.qubits[0]
                     global_measurement_indices[-1][qubit] = global_measurement_index
                     global_measurement_index += 1

--- a/src/tqec/detectors/operation.py
+++ b/src/tqec/detectors/operation.py
@@ -1,5 +1,7 @@
-from typing import Any
+from __future__ import annotations
+
 from dataclasses import dataclass
+from typing import Any
 
 import cirq
 
@@ -14,7 +16,7 @@ class ShiftCoords(cirq.Operation):
         WARNING: you should use `make_shift_coords` to create instances of this class.
         If you do not, read attentively the documentation below.
 
-        This is a replication of the 
+        This is a replication of the
         [stimcirq.ShiftCoordsAnnotation](https://github.com/quantumlib/Stim/blob/main/glue/cirq/stimcirq/_shift_coords_annotation.py)
         class. We can directly use `stimcirq.ShiftCoordsAnnotation` here, however,
         replication brings the class into the `tqec` namespace and is useful for the
@@ -42,10 +44,10 @@ class ShiftCoords(cirq.Operation):
         return self._shifts
 
     @property
-    def qubits(self) -> tuple['cirq.Qid', ...]:
+    def qubits(self) -> tuple[cirq.Qid, ...]:
         return ()
 
-    def with_qubits(self, *new_qubits: 'cirq.Qid') -> "ShiftCoords":
+    def with_qubits(self, *new_qubits: cirq.Qid) -> "ShiftCoords":
         return self
 
 
@@ -96,10 +98,10 @@ class RelativeMeasurementsRecord(cirq.Operation):
         self._data = data
 
     @property
-    def qubits(self) -> tuple['cirq.Qid', ...]:
+    def qubits(self) -> tuple[cirq.Qid, ...]:
         return ()
 
-    def with_qubits(self, *new_qubits: 'cirq.Qid') -> "RelativeMeasurementsRecord":
+    def with_qubits(self, *new_qubits: cirq.Qid) -> "RelativeMeasurementsRecord":
         return self
 
     @property
@@ -225,9 +227,9 @@ def make_shift_coords(*shifts: int) -> cirq.Operation:
 
 
 def make_detector(
-        local_coordinate_system_origin: cirq.GridQubit,
-        relative_measurements: list[tuple[cirq.GridQubit, int] | RelativeMeasurementData],
-        time_coordinate: int = 0,
+    local_coordinate_system_origin: cirq.GridQubit,
+    relative_measurements: list[tuple[cirq.GridQubit, int] | RelativeMeasurementData],
+    time_coordinate: int = 0,
 ) -> cirq.Operation:
     """This is a helper function to make a :class:`Detector` operation with the
     `cirq.VirtualTag` tag.
@@ -252,20 +254,20 @@ def make_detector(
         A :class:`Detector` operation with the `cirq.VirtualTag` tag.
     """
     relative_measurements_data = [
-        RelativeMeasurementData(*rm) if not isinstance(rm, RelativeMeasurementData) else rm
+        RelativeMeasurementData(*rm)
+        if not isinstance(rm, RelativeMeasurementData)
+        else rm
         for rm in relative_measurements
     ]
     return Detector(
-        local_coordinate_system_origin,
-        relative_measurements_data,
-        time_coordinate
+        local_coordinate_system_origin, relative_measurements_data, time_coordinate
     ).with_tags(cirq.VirtualTag(), STIM_TAG)
 
 
 def make_observable(
-        local_coordinate_system_origin: cirq.GridQubit,
-        relative_measurements: list[tuple[cirq.GridQubit, int] | RelativeMeasurementData],
-        observable_index: int = 0,
+    local_coordinate_system_origin: cirq.GridQubit,
+    relative_measurements: list[tuple[cirq.GridQubit, int] | RelativeMeasurementData],
+    observable_index: int = 0,
 ) -> cirq.Operation:
     """This is a helper function to make a :class:`Observable` operation with the
     `cirq.VirtualTag` tag.
@@ -289,11 +291,11 @@ def make_observable(
         A :class:`Observable` operation with the `cirq.VirtualTag` tag.
     """
     relative_measurements_data = [
-        RelativeMeasurementData(*rm) if not isinstance(rm, RelativeMeasurementData) else rm
+        RelativeMeasurementData(*rm)
+        if not isinstance(rm, RelativeMeasurementData)
+        else rm
         for rm in relative_measurements
     ]
     return Observable(
-        local_coordinate_system_origin,
-        relative_measurements_data,
-        observable_index
+        local_coordinate_system_origin, relative_measurements_data, observable_index
     ).with_tags(cirq.VirtualTag(), STIM_TAG)

--- a/src/tqec/detectors/transformer.py
+++ b/src/tqec/detectors/transformer.py
@@ -1,18 +1,22 @@
+from __future__ import annotations
+
 from copy import deepcopy
 
 import cirq
 import numpy
 import stimcirq
 import sympy
-
-from tqec.exceptions import TQECException
+from tqec.detectors.measurement_map import (
+    CircuitMeasurementMap,
+    compute_global_measurements_lookback_offsets,
+)
 from tqec.detectors.operation import (
-    ShiftCoords,
+    STIM_TAG,
     Detector,
     Observable,
-    STIM_TAG,
+    ShiftCoords,
 )
-from tqec.detectors.measurement_map import CircuitMeasurementMap, compute_global_measurements_lookback_offsets
+from tqec.exceptions import TQECException
 
 
 def _transform_to_stimcirq_compatible_impl(
@@ -120,7 +124,9 @@ def transform_to_stimcirq_compatible(
     """
     _annotation_safety_check(circuit)
     measurement_map = CircuitMeasurementMap(circuit)
-    transformed_circuit, _ = _transform_to_stimcirq_compatible_impl(circuit, measurement_map, 0)
+    transformed_circuit, _ = _transform_to_stimcirq_compatible_impl(
+        circuit, measurement_map, 0
+    )
     return transformed_circuit
 
 

--- a/src/tqec/display.py
+++ b/src/tqec/display.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import math
 import pathlib
 

--- a/src/tqec/generation/circuit.py
+++ b/src/tqec/generation/circuit.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from copy import deepcopy
 
 import cirq

--- a/src/tqec/plaquette/plaquette.py
+++ b/src/tqec/plaquette/plaquette.py
@@ -1,10 +1,9 @@
 import cirq
-
 from tqec.enums import PlaquetteOrientation
+from tqec.exceptions import TQECException
 from tqec.plaquette.qubit import PlaquetteQubit
 from tqec.plaquette.schedule import ScheduledCircuit
 from tqec.position import Position
-from tqec.exceptions import TQECException
 
 
 class Plaquette:

--- a/src/tqec/plaquette/schedule.py
+++ b/src/tqec/plaquette/schedule.py
@@ -1,9 +1,10 @@
+from __future__ import annotations
+
 import numbers
 import typing
 from copy import deepcopy
 
 import cirq
-
 from tqec.detectors.operation import Detector, make_detector
 from tqec.exceptions import TQECException
 
@@ -110,7 +111,8 @@ class ScheduledCircuit:
             if not isinstance(q, cirq.GridQubit):
                 raise TQECException(
                     f"Excepted only instances of 'cirq.GridQubit', "
-                    f"but found an instance of {q.__class__.__name__}.")
+                    f"but found an instance of {q.__class__.__name__}."
+                )
 
         # Check that all entries in the provided schedule are integers.
         for entry in schedule:

--- a/src/tqec/templates/base.py
+++ b/src/tqec/templates/base.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import typing as ty
 from abc import ABC, abstractmethod

--- a/src/tqec/templates/constructions/qubit.py
+++ b/src/tqec/templates/constructions/qubit.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from tqec.enums import ABOVE_OF, BELOW_OF, LEFT_OF, RIGHT_OF
 from tqec.templates.base import TemplateWithIndices
 from tqec.templates.composed import ComposedTemplate

--- a/src/tqec/templates/scalable/rectangle.py
+++ b/src/tqec/templates/scalable/rectangle.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from tqec.exceptions import TQECException
 from tqec.templates.base import Template
 from tqec.templates.scalable.base import ScalableTemplate


### PR DESCRIPTION
This PR adds support for Python 3.9, mostly by adding `from __future__ import annotations` at the top of files that are using [PEP 604](https://peps.python.org/pep-0604/).

Fixes #123.