### PR TITLE
Decouple Plaquette and qubits

### DIFF
--- a/notebooks/corner.ipynb
+++ b/notebooks/corner.ipynb
@@ -30,7 +30,7 @@
          "source": [
             "from tqec.templates.constructions.corner import ScalableCorner\n",
             "from tqec.templates.scale import Dimension, LinearFunction\n",
-            "from tqec.display import display_template\n",
+            "from tqec.templates.display import display_template\n",
             "\n",
             "# Corner made of 2*2=4 plaquettes for the scaled distances.\n",
             "corner = ScalableCorner(Dimension(2, LinearFunction(2)))\n",
@@ -114,7 +114,15 @@
          "name": "python3"
       },
       "language_info": {
+         "codemirror_mode": {
+            "name": "ipython",
+            "version": 3
+         },
+         "file_extension": ".py",
+         "mimetype": "text/x-python",
          "name": "python",
+         "nbconvert_exporter": "python",
+         "pygments_lexer": "ipython3",
          "version": "3.12.0"
       }
    },

--- a/notebooks/doubling_distance.ipynb
+++ b/notebooks/doubling_distance.ipynb
@@ -108,7 +108,7 @@
                 "        self,\n",
                 "        plaquette_indices: ty.Sequence[int],\n",
                 "    ) -> numpy.ndarray:\n",
-                "        self._check_plaquette_number(plaquette_indices)\n",
+                "        self._check_plaquette_number(plaquette_indices, 3)\n",
                 "        x_plaquette, z_plaquette, special_plaquette = plaquette_indices[:3]\n",
                 "        arr = super().instantiate([x_plaquette, z_plaquette])\n",
                 "        arr[0, -1] = special_plaquette\n",
@@ -329,7 +329,7 @@
             },
             "outputs": [],
             "source": [
-                "from tqec.display import display_template\n",
+                "from tqec.templates.display import display_template\n",
                 "\n",
                 "display_template(doubling_template)"
             ]

--- a/notebooks/logical_qubit_extended_memory_experiment.ipynb
+++ b/notebooks/logical_qubit_extended_memory_experiment.ipynb
@@ -32,10 +32,10 @@
                 "\n",
                 "from tqec.templates.constructions.qubit import QubitRectangleTemplate\n",
                 "from tqec.templates.scale import Dimension, LinearFunction\n",
-                "from tqec.detectors.operation import make_shift_coords, make_observable\n",
-                "from tqec.detectors.transformer import transform_to_stimcirq_compatible\n",
+                "from tqec.circuit.operations.operation import make_shift_coords, make_observable\n",
+                "from tqec.circuit.operations.transformer import transform_to_stimcirq_compatible\n",
                 "from tqec.enums import PlaquetteOrientation\n",
-                "from tqec.generation.circuit import generate_circuit\n",
+                "from tqec.circuit.circuit import generate_circuit\n",
                 "from tqec.noise_models import (\n",
                 "    AfterCliffordDepolarizingNoise,\n",
                 "    AfterResetFlipNoise,\n",
@@ -52,7 +52,7 @@
                 "    MeasurementRoundedPlaquette,\n",
                 "    MeasurementSquarePlaquette,\n",
                 ")\n",
-                "from tqec.display import display_template"
+                "from tqec.templates.display import display_template"
             ]
         },
         {

--- a/notebooks/logical_qubit_memory_experiment.ipynb
+++ b/notebooks/logical_qubit_memory_experiment.ipynb
@@ -30,10 +30,10 @@
             "\n",
             "from tqec.templates.constructions.qubit import QubitSquareTemplate\n",
             "from tqec.templates.scale import Dimension, LinearFunction\n",
-            "from tqec.detectors.operation import make_observable, make_shift_coords\n",
-            "from tqec.detectors.transformer import transform_to_stimcirq_compatible\n",
+            "from tqec.circuit.operations.operation import make_observable, make_shift_coords\n",
+            "from tqec.circuit.operations.transformer import transform_to_stimcirq_compatible\n",
             "from tqec.enums import PlaquetteOrientation\n",
-            "from tqec.generation.circuit import generate_circuit\n",
+            "from tqec.circuit.circuit import generate_circuit\n",
             "from tqec.noise_models import (\n",
             "    AfterCliffordDepolarizingNoise,\n",
             "    AfterResetFlipNoise,\n",
@@ -414,27 +414,8 @@
          "metadata": {},
          "outputs": [],
          "source": [
-            "export_stim_files = True\n",
-            "\n",
             "stim_circuit_stim = generate_stim_circuit_stim(3, 0.001, 2)\n",
-            "stim_circuit_tqec = generate_stim_circuit_tqec(3, 0.001, 2)\n",
-            "if export_stim_files:\n",
-            "    with open(\"./stim.stim\", \"w\") as f:\n",
-            "        f.write(str(stim_circuit_stim))\n",
-            "    with open(\"./tqec.stim\", \"w\") as f:\n",
-            "        f.write(str(stim_circuit_tqec))\n",
-            "    print(\"Export done!\")"
-         ]
-      },
-      {
-         "cell_type": "code",
-         "execution_count": null,
-         "metadata": {},
-         "outputs": [],
-         "source": [
-            "if export_stim_files:\n",
-            "    with open(\"./tqec.stim\", \"r\") as f:\n",
-            "        stim_circuit_tqec = stim.Circuit(f.read())"
+            "stim_circuit_tqec = generate_stim_circuit_tqec(3, 0.001, 2)"
          ]
       },
       {

--- a/notebooks/move_qubit_along_a_line.ipynb
+++ b/notebooks/move_qubit_along_a_line.ipynb
@@ -59,15 +59,15 @@
                 "from tqec.templates.scale import Dimension, FixedDimension, LinearFunction\n",
                 "from tqec.templates.composed import ComposedTemplate\n",
                 "from tqec.templates.base import TemplateWithIndices\n",
-                "from tqec.detectors.operation import (\n",
+                "from tqec.circuit.operations.operation import (\n",
                 "    make_shift_coords,\n",
                 "    make_observable,\n",
                 "    Detector,\n",
                 "    make_detector,\n",
                 ")\n",
-                "from tqec.detectors.transformer import transform_to_stimcirq_compatible\n",
+                "from tqec.circuit.operations.transformer import transform_to_stimcirq_compatible\n",
                 "from tqec.enums import PlaquetteOrientation, ABOVE_OF, BELOW_OF, LEFT_OF, RIGHT_OF\n",
-                "from tqec.generation.circuit import generate_circuit\n",
+                "from tqec.circuit.circuit import generate_circuit\n",
                 "from tqec.noise_models import (\n",
                 "    AfterCliffordDepolarizingNoise,\n",
                 "    AfterResetFlipNoise,\n",
@@ -85,7 +85,7 @@
                 "    MeasurementSquarePlaquette,\n",
                 "    MeasurementRoundedPlaquette,\n",
                 ")\n",
-                "from tqec.display import display_template"
+                "from tqec.templates.display import display_template"
             ]
         },
         {

--- a/src/tqec/__init__.py
+++ b/src/tqec/__init__.py
@@ -5,7 +5,12 @@ from . import (
     templates,
 )
 from ._version import __version__
-from .circuit import generate_circuit
+from .circuit import (
+    ScheduledCircuit,
+    ScheduleException,
+    generate_circuit,
+    merge_scheduled_circuits,
+)
 from .enums import (
     CornerPositionEnum,
     PlaquetteOrientation,
@@ -24,10 +29,9 @@ from .noise_models import (
 from .plaquette import (
     Plaquette,
     PlaquetteQubit,
-    RoundedPlaquette,
-    ScheduledCircuit,
-    ScheduleException,
-    SquarePlaquette,
+    PlaquetteQubits,
+    RoundedPlaquetteQubits,
+    SquarePlaquetteQubits,
 )
 from .position import (
     Displacement,

--- a/src/tqec/circuit/__init__.py
+++ b/src/tqec/circuit/__init__.py
@@ -6,3 +6,4 @@ from .operations import (
     make_shift_coords,
     transform_to_stimcirq_compatible,
 )
+from .schedule import ScheduledCircuit, ScheduleException, merge_scheduled_circuits

--- a/src/tqec/plaquette/__init__.py
+++ b/src/tqec/plaquette/__init__.py
@@ -1,10 +1,7 @@
-from .plaquette import (
-    Plaquette,
-    RoundedPlaquette,
-    SquarePlaquette,
-)
-from .qubit import PlaquetteQubit
-from ..circuit.schedule import (
-    ScheduledCircuit,
-    ScheduleException,
+from .plaquette import Plaquette
+from .qubit import (
+    PlaquetteQubit,
+    PlaquetteQubits,
+    RoundedPlaquetteQubits,
+    SquarePlaquetteQubits,
 )

--- a/src/tqec/plaquette/library/empty.py
+++ b/src/tqec/plaquette/library/empty.py
@@ -1,14 +1,25 @@
 import cirq
-from tqec.enums import PlaquetteOrientation
-from tqec.plaquette.plaquette import RoundedPlaquette, SquarePlaquette
+
 from tqec.circuit.schedule import ScheduledCircuit
+from tqec.enums import PlaquetteOrientation
+from tqec.plaquette.plaquette import Plaquette
+from tqec.plaquette.qubit import (
+    PlaquetteQubits,
+    RoundedPlaquetteQubits,
+    SquarePlaquetteQubits,
+)
 
 
-class EmptySquarePlaquette(SquarePlaquette):
+class EmptyPlaquette(Plaquette):
+    def __init__(self, qubits: PlaquetteQubits) -> None:
+        super().__init__(qubits, ScheduledCircuit(cirq.Circuit()))
+
+
+class EmptySquarePlaquette(EmptyPlaquette):
     def __init__(self) -> None:
-        super().__init__(ScheduledCircuit(cirq.Circuit()))
+        super().__init__(SquarePlaquetteQubits())
 
 
-class EmptyRoundedPlaquette(RoundedPlaquette):
+class EmptyRoundedPlaquette(EmptyPlaquette):
     def __init__(self, orientation: PlaquetteOrientation) -> None:
-        super().__init__(ScheduledCircuit(cirq.Circuit()), orientation)
+        super().__init__(RoundedPlaquetteQubits(orientation))

--- a/src/tqec/plaquette/library/initialisation.py
+++ b/src/tqec/plaquette/library/initialisation.py
@@ -1,74 +1,49 @@
 from __future__ import annotations
 
-import typing as ty
-
 import cirq
-from tqec.enums import PlaquetteOrientation
-from tqec.plaquette.plaquette import RoundedPlaquette, SquarePlaquette
+
 from tqec.circuit.schedule import ScheduledCircuit
+from tqec.enums import PlaquetteOrientation
+from tqec.plaquette.plaquette import Plaquette
+from tqec.plaquette.qubit import (
+    PlaquetteQubits,
+    RoundedPlaquetteQubits,
+    SquarePlaquetteQubits,
+)
 
 
-class ZSquareInitialisationPlaquette(SquarePlaquette):
-    def __init__(
-        self, qubits_to_initialise: ty.Sequence[cirq.GridQubit] | None = None
-    ) -> None:
-        if qubits_to_initialise is None:
-            qubits_to_initialise = (
-                SquarePlaquette.get_data_qubits_cirq()
-                + SquarePlaquette.get_syndrome_qubits_cirq()
-            )
+class ZInitialisationPlaquette(Plaquette):
+    def __init__(self, qubits: PlaquetteQubits) -> None:
         circuit = cirq.Circuit(
-            cirq.R(q).with_tags(self._MERGEABLE_TAG) for q in qubits_to_initialise
+            cirq.R(q).with_tags(self._MERGEABLE_TAG) for q in qubits.to_grid_qubit()
         )
-        super().__init__(ScheduledCircuit(circuit))
+        super().__init__(qubits, ScheduledCircuit(circuit))
 
 
-class ZRoundedInitialisationPlaquette(RoundedPlaquette):
-    def __init__(
-        self,
-        orientation: PlaquetteOrientation,
-        qubits_to_initialise: ty.Sequence[cirq.GridQubit] | None = None,
-    ) -> None:
-        if qubits_to_initialise is None:
-            qubits_to_initialise = (
-                RoundedPlaquette.get_data_qubits_cirq(orientation)
-                + RoundedPlaquette.get_syndrome_qubits_cirq()
-            )
-        circuit = cirq.Circuit(
-            cirq.R(q).with_tags(self._MERGEABLE_TAG) for q in qubits_to_initialise
-        )
-        super().__init__(ScheduledCircuit(circuit), orientation)
+class ZSquareInitialisationPlaquette(ZInitialisationPlaquette):
+    def __init__(self) -> None:
+        super().__init__(SquarePlaquetteQubits())
 
 
-class XSquareInitialisationPlaquette(SquarePlaquette):
-    def __init__(
-        self, qubits_to_initialise: ty.Sequence[cirq.GridQubit] | None = None
-    ) -> None:
-        if qubits_to_initialise is None:
-            qubits_to_initialise = (
-                SquarePlaquette.get_data_qubits_cirq()
-                + SquarePlaquette.get_syndrome_qubits_cirq()
-            )
+class ZRoundedInitialisationPlaquette(ZInitialisationPlaquette):
+    def __init__(self, orientation: PlaquetteOrientation) -> None:
+        super().__init__(RoundedPlaquetteQubits(orientation))
+
+
+class XInitialisationPlaquette(Plaquette):
+    def __init__(self, qubits: PlaquetteQubits) -> None:
         circuit = cirq.Circuit(
             (cirq.R(q).with_tags(self._MERGEABLE_TAG), cirq.H(q))
-            for q in qubits_to_initialise
+            for q in qubits.to_grid_qubit()
         )
-        super().__init__(ScheduledCircuit(circuit))
+        super().__init__(qubits, ScheduledCircuit(circuit))
 
 
-class XRoundedInitialisationPlaquette(RoundedPlaquette):
-    def __init__(
-        self,
-        orientation: PlaquetteOrientation,
-        qubits_to_initialise: ty.Sequence[cirq.GridQubit] | None = None,
-    ) -> None:
-        if qubits_to_initialise is None:
-            qubits_to_initialise = (
-                RoundedPlaquette.get_data_qubits_cirq(orientation)
-                + RoundedPlaquette.get_syndrome_qubits_cirq()
-            )
-        circuit = cirq.Circuit(
-            (cirq.R(q).with_tags(self._MERGEABLE_TAG), cirq.H(q))
-            for q in qubits_to_initialise
-        )
-        super().__init__(ScheduledCircuit(circuit), orientation)
+class XSquareInitialisationPlaquette(XInitialisationPlaquette):
+    def __init__(self) -> None:
+        super().__init__(SquarePlaquetteQubits())
+
+
+class XRoundedInitialisationPlaquette(XInitialisationPlaquette):
+    def __init__(self, orientation: PlaquetteOrientation) -> None:
+        super().__init__(RoundedPlaquetteQubits(orientation))

--- a/src/tqec/plaquette/library/measurement.py
+++ b/src/tqec/plaquette/library/measurement.py
@@ -3,51 +3,25 @@ import cirq
 from tqec.circuit.operations.operation import make_detector
 from tqec.circuit.schedule import ScheduledCircuit
 from tqec.enums import PlaquetteOrientation
-from tqec.plaquette.plaquette import RoundedPlaquette, SquarePlaquette
+from tqec.plaquette.plaquette import Plaquette
+from tqec.plaquette.qubit import (
+    PlaquetteQubits,
+    RoundedPlaquetteQubits,
+    SquarePlaquetteQubits,
+)
 
 
-class MeasurementRoundedPlaquette(RoundedPlaquette):
-    def __init__(
-        self,
-        orientation: PlaquetteOrientation,
-        include_detector: bool = True,
-    ):
-        (syndrome_qubit,) = self.get_syndrome_qubits_cirq()
-        data_qubits = self.get_data_qubits_cirq(orientation)
+class MeasurementPlaquette(Plaquette):
+    def __init__(self, qubits: PlaquetteQubits, include_detector: bool = True):
+        (syndrome_qubit,) = qubits.get_syndrome_qubits_cirq()
+        data_qubits = qubits.get_data_qubits_cirq()
         measurement_qubits = [syndrome_qubit, *data_qubits]
         detector = make_detector(
             syndrome_qubit,
             [(meas_qubit - syndrome_qubit, -1) for meas_qubit in measurement_qubits],
         )
         super().__init__(
-            circuit=ScheduledCircuit(
-                cirq.Circuit(
-                    [
-                        cirq.Moment(
-                            cirq.M(q).with_tags(self._MERGEABLE_TAG)
-                            for q in data_qubits
-                        ),
-                        cirq.Moment(detector) if include_detector else [],
-                    ]
-                ),
-            ),
-            orientation=orientation,
-        )
-
-
-class MeasurementSquarePlaquette(SquarePlaquette):
-    def __init__(
-        self,
-        include_detector: bool = True,
-    ):
-        (syndrome_qubit,) = self.get_syndrome_qubits_cirq()
-        data_qubits = self.get_data_qubits_cirq()
-        measurement_qubits = [syndrome_qubit, *data_qubits]
-        detector = make_detector(
-            syndrome_qubit,
-            [(meas_qubit - syndrome_qubit, -1) for meas_qubit in measurement_qubits],
-        )
-        super().__init__(
+            qubits,
             circuit=ScheduledCircuit(
                 cirq.Circuit(
                     [
@@ -60,3 +34,15 @@ class MeasurementSquarePlaquette(SquarePlaquette):
                 ),
             ),
         )
+
+
+class MeasurementRoundedPlaquette(MeasurementPlaquette):
+    def __init__(
+        self, orientation: PlaquetteOrientation, include_detector: bool = True
+    ):
+        super().__init__(RoundedPlaquetteQubits(orientation), include_detector)
+
+
+class MeasurementSquarePlaquette(MeasurementPlaquette):
+    def __init__(self, include_detector: bool = True):
+        super().__init__(SquarePlaquetteQubits(), include_detector)

--- a/src/tqec/plaquette/library/xx.py
+++ b/src/tqec/plaquette/library/xx.py
@@ -2,14 +2,15 @@ from __future__ import annotations
 
 import cirq
 
+from tqec.circuit.schedule import ScheduledCircuit
 from tqec.enums import PlaquetteOrientation
 from tqec.plaquette.library.utils.detectors import make_memory_experiment_detector
 from tqec.plaquette.library.utils.pauli import make_pauli_syndrome_measurement_circuit
-from tqec.plaquette.plaquette import RoundedPlaquette
-from tqec.circuit.schedule import ScheduledCircuit
+from tqec.plaquette.plaquette import Plaquette
+from tqec.plaquette.qubit import RoundedPlaquetteQubits
 
 
-class XXMemoryPlaquette(RoundedPlaquette):
+class XXMemoryPlaquette(Plaquette):
     def __init__(
         self,
         orientation: PlaquetteOrientation,
@@ -17,8 +18,9 @@ class XXMemoryPlaquette(RoundedPlaquette):
         include_detector: bool = True,
         is_first_round: bool = False,
     ):
-        (syndrome_qubit,) = RoundedPlaquette.get_syndrome_qubits()
-        data_qubits = RoundedPlaquette.get_data_qubits(orientation)
+        qubits = RoundedPlaquetteQubits(orientation)
+        (syndrome_qubit,) = qubits.get_syndrome_qubits()
+        data_qubits = qubits.get_data_qubits()
 
         circuit = make_pauli_syndrome_measurement_circuit(
             syndrome_qubit, data_qubits, "XX"
@@ -30,7 +32,4 @@ class XXMemoryPlaquette(RoundedPlaquette):
                 )
             )
 
-        super().__init__(
-            ScheduledCircuit(circuit, schedule),
-            orientation,
-        )
+        super().__init__(qubits, ScheduledCircuit(circuit, schedule))

--- a/src/tqec/plaquette/library/xxxx.py
+++ b/src/tqec/plaquette/library/xxxx.py
@@ -2,21 +2,23 @@ from __future__ import annotations
 
 import cirq
 
+from tqec.circuit.schedule import ScheduledCircuit
 from tqec.plaquette.library.utils.detectors import make_memory_experiment_detector
 from tqec.plaquette.library.utils.pauli import make_pauli_syndrome_measurement_circuit
-from tqec.plaquette.plaquette import SquarePlaquette
-from tqec.circuit.schedule import ScheduledCircuit
+from tqec.plaquette.plaquette import Plaquette
+from tqec.plaquette.qubit import SquarePlaquetteQubits
 
 
-class XXXXMemoryPlaquette(SquarePlaquette):
+class XXXXMemoryPlaquette(Plaquette):
     def __init__(
         self,
         schedule: list[int],
         include_detector: bool = True,
         is_first_round: bool = False,
     ):
-        (syndrome_qubit,) = SquarePlaquette.get_syndrome_qubits()
-        data_qubits = SquarePlaquette.get_data_qubits()
+        qubits = SquarePlaquetteQubits()
+        (syndrome_qubit,) = qubits.get_syndrome_qubits()
+        data_qubits = qubits.get_data_qubits()
 
         circuit = make_pauli_syndrome_measurement_circuit(
             syndrome_qubit, data_qubits, "XXXX"
@@ -28,4 +30,4 @@ class XXXXMemoryPlaquette(SquarePlaquette):
                 )
             )
 
-        super().__init__(ScheduledCircuit(circuit, schedule))
+        super().__init__(qubits, ScheduledCircuit(circuit, schedule))

--- a/src/tqec/plaquette/library/zz.py
+++ b/src/tqec/plaquette/library/zz.py
@@ -2,14 +2,15 @@ from __future__ import annotations
 
 import cirq
 
+from tqec.circuit.schedule import ScheduledCircuit
 from tqec.enums import PlaquetteOrientation
 from tqec.plaquette.library.utils.detectors import make_memory_experiment_detector
 from tqec.plaquette.library.utils.pauli import make_pauli_syndrome_measurement_circuit
-from tqec.plaquette.plaquette import RoundedPlaquette
-from tqec.circuit.schedule import ScheduledCircuit
+from tqec.plaquette.plaquette import Plaquette
+from tqec.plaquette.qubit import RoundedPlaquetteQubits
 
 
-class ZZMemoryPlaquette(RoundedPlaquette):
+class ZZMemoryPlaquette(Plaquette):
     def __init__(
         self,
         orientation: PlaquetteOrientation,
@@ -17,8 +18,9 @@ class ZZMemoryPlaquette(RoundedPlaquette):
         include_detector: bool = True,
         is_first_round: bool = False,
     ):
-        (syndrome_qubit,) = RoundedPlaquette.get_syndrome_qubits()
-        data_qubits = RoundedPlaquette.get_data_qubits(orientation)
+        qubits = RoundedPlaquetteQubits(orientation)
+        (syndrome_qubit,) = qubits.get_syndrome_qubits()
+        data_qubits = qubits.get_data_qubits()
 
         circuit = make_pauli_syndrome_measurement_circuit(
             syndrome_qubit, data_qubits, "ZZ"
@@ -30,7 +32,4 @@ class ZZMemoryPlaquette(RoundedPlaquette):
                 )
             )
 
-        super().__init__(
-            ScheduledCircuit(circuit, schedule),
-            orientation,
-        )
+        super().__init__(qubits, ScheduledCircuit(circuit, schedule))

--- a/src/tqec/plaquette/library/zzzz.py
+++ b/src/tqec/plaquette/library/zzzz.py
@@ -2,21 +2,23 @@ from __future__ import annotations
 
 import cirq
 
+from tqec.circuit.schedule import ScheduledCircuit
 from tqec.plaquette.library.utils.detectors import make_memory_experiment_detector
 from tqec.plaquette.library.utils.pauli import make_pauli_syndrome_measurement_circuit
-from tqec.plaquette.plaquette import SquarePlaquette
-from tqec.circuit.schedule import ScheduledCircuit
+from tqec.plaquette.plaquette import Plaquette
+from tqec.plaquette.qubit import SquarePlaquetteQubits
 
 
-class ZZZZMemoryPlaquette(SquarePlaquette):
+class ZZZZMemoryPlaquette(Plaquette):
     def __init__(
         self,
         schedule: list[int],
         include_detector: bool = True,
         is_first_round: bool = False,
     ):
-        (syndrome_qubit,) = SquarePlaquette.get_syndrome_qubits()
-        data_qubits = SquarePlaquette.get_data_qubits()
+        qubits = SquarePlaquetteQubits()
+        (syndrome_qubit,) = qubits.get_syndrome_qubits()
+        data_qubits = qubits.get_data_qubits()
 
         circuit = make_pauli_syndrome_measurement_circuit(
             syndrome_qubit, [data_qubits[i] for i in [0, 2, 1, 3]], "ZZZZ"
@@ -28,4 +30,4 @@ class ZZZZMemoryPlaquette(SquarePlaquette):
                 )
             )
 
-        super().__init__(ScheduledCircuit(circuit, schedule))
+        super().__init__(qubits, ScheduledCircuit(circuit, schedule))

--- a/src/tqec/plaquette/plaquette.py
+++ b/src/tqec/plaquette/plaquette.py
@@ -1,9 +1,8 @@
 import cirq
 
 from tqec.circuit.schedule import ScheduledCircuit
-from tqec.enums import PlaquetteOrientation, PlaquetteSide
 from tqec.exceptions import TQECException
-from tqec.plaquette.qubit import PlaquetteQubit
+from tqec.plaquette.qubit import PlaquetteQubits
 from tqec.position import Position
 
 
@@ -16,7 +15,7 @@ class Plaquette:
 
     def __init__(
         self,
-        qubits: list[PlaquetteQubit],
+        qubits: PlaquetteQubits,
         circuit: ScheduledCircuit,
     ) -> None:
         """Represents a QEC plaquette
@@ -53,139 +52,9 @@ class Plaquette:
         return Position(0, 0)
 
     @property
-    def qubits(self) -> list[PlaquetteQubit]:
+    def qubits(self) -> PlaquetteQubits:
         return self._qubits
 
     @property
     def circuit(self) -> ScheduledCircuit:
         return self._circuit
-
-
-class SquarePlaquette(Plaquette):
-    def __init__(self, circuit: ScheduledCircuit) -> None:
-        """Represents a square QEC plaquette
-
-        By convention, the qubits are sorted as depicted in the text below:
-        ```text
-        |---------|
-        | 1     2 |
-        |         |
-        | 3     4 |
-        |---------|
-        ```
-        Sub-classes of this class should take that into account to apply operations
-        on the correct qubits.
-        This ordering is not to be confused with the temporal ordering of multi-qubit
-        gates, for example in surface codes. It is a **qubit** ordering and has **no
-        relation** with a temporal ordering.
-
-        Args:
-            circuit: scheduled quantum circuit implementing the computation that
-                the plaquette should represent.
-        """
-        super().__init__(
-            SquarePlaquette.get_data_qubits() + SquarePlaquette.get_syndrome_qubits(),
-            circuit,
-        )
-
-    _data_qubits: list[PlaquetteQubit] = [
-        PlaquetteQubit(Position(-1, -1)),
-        PlaquetteQubit(Position(1, -1)),
-        PlaquetteQubit(Position(-1, 1)),
-        PlaquetteQubit(Position(1, 1)),
-    ]
-    _syndrome_qubits = [PlaquetteQubit(Position(0, 0))]
-
-    @staticmethod
-    def get_data_qubits() -> list[PlaquetteQubit]:
-        return SquarePlaquette._data_qubits
-
-    @staticmethod
-    def get_syndrome_qubits() -> list[PlaquetteQubit]:
-        return SquarePlaquette._syndrome_qubits
-
-    @staticmethod
-    def get_data_qubits_cirq() -> list[cirq.GridQubit]:
-        return [q.to_grid_qubit() for q in SquarePlaquette.get_data_qubits()]
-
-    @staticmethod
-    def get_syndrome_qubits_cirq() -> list[cirq.GridQubit]:
-        return [q.to_grid_qubit() for q in SquarePlaquette.get_syndrome_qubits()]
-
-    @staticmethod
-    def get_qubits_on_side(side: PlaquetteSide) -> list[PlaquetteQubit]:
-        data_indices: tuple[int, int]
-        if side == PlaquetteSide.LEFT:
-            data_indices = (0, 2)
-        elif side == PlaquetteSide.RIGHT:
-            data_indices = (1, 3)
-        elif side == PlaquetteSide.UP:
-            data_indices = (0, 1)
-        else:  # if orientation == PlaquetteSide.DOWN:
-            data_indices = (2, 3)
-        return [SquarePlaquette._data_qubits[i] for i in data_indices]
-
-
-class RoundedPlaquette(SquarePlaquette):
-    def __init__(
-        self,
-        circuit: ScheduledCircuit,
-        orientation: PlaquetteOrientation,
-        add_unused_qubits: bool = False,
-    ) -> None:
-        """Represents a rounded QEC plaquette
-
-        By convention, the qubits are sorted as depicted in the text below:
-        ```text
-        |---------|
-        | 1     2 |
-        |         |
-        | 3     4 |
-        |---------|
-        ```
-
-        This means that an instance of a subclass of this class with a
-        PlaquetteOrientation.UP orientation will have its two qubits ordered as
-        ```text
-          -------
-         /       \\
-        | 1     2 |
-        |---------|
-        ```
-        as `3` (the index of the bottom-right qubit in the initial ordering) is the
-        lowest index (i.e., the number `1`) and `4` follows.
-
-        Subclasses of this class should take that into account to apply operations
-        on the correct qubits.
-        This ordering is not to be confused with the temporal ordering of multi-qubit
-        gates, for example in surface codes. It is a **qubit** ordering and has **no
-        relation** with a temporal ordering.
-
-        Args:
-            circuit: scheduled quantum circuit implementing the computation that
-                the plaquette should represent.
-            orientation: side at which the plaquette is "pointing at". An
-                orientation of PlaquetteOrientation.UP will generate a plaquette
-                with its rounded side pointing up.
-        """
-        super().__init__(circuit)
-        self._orientation = orientation
-
-    @staticmethod
-    def get_data_qubits(orientation: PlaquetteOrientation) -> list[PlaquetteQubit]:
-        """Returns the two data qubits of the plaquette
-
-        This method returns the 2 data qubits according to the plaquette orientation. Taking
-        the example from the class docstring, an orientation of PlaquetteOrientation.UP
-        will return the qubits indexed 3 and 4 (or 2 and 3 in a 0-based indexing).
-
-        Args:
-            orientation: plaquette orientation
-        """
-        return RoundedPlaquette.get_qubits_on_side(orientation.to_plaquette_side())
-
-    @staticmethod
-    def get_data_qubits_cirq(orientation: PlaquetteOrientation) -> list[cirq.GridQubit]:
-        return [
-            q.to_grid_qubit() for q in RoundedPlaquette.get_data_qubits(orientation)
-        ]

--- a/src/tqec/plaquette/qubit.py
+++ b/src/tqec/plaquette/qubit.py
@@ -1,6 +1,9 @@
+import typing as ty
 from dataclasses import dataclass
 
-from cirq import GridQubit
+import cirq
+
+from tqec.enums import PlaquetteOrientation, PlaquetteSide
 from tqec.position import Position
 
 
@@ -17,6 +20,73 @@ class PlaquetteQubit:
 
     position: Position
 
-    def to_grid_qubit(self) -> GridQubit:
+    def to_grid_qubit(self) -> cirq.GridQubit:
         # GridQubit are indexed as (row, col)
-        return GridQubit(self.position.y, self.position.x)
+        return cirq.GridQubit(self.position.y, self.position.x)
+
+
+@dataclass(frozen=True)
+class PlaquetteQubits:
+    data_qubits: list[PlaquetteQubit]
+    syndrome_qubits: list[PlaquetteQubit]
+
+    def get_data_qubits(self) -> list[PlaquetteQubit]:
+        return self.data_qubits
+
+    def get_syndrome_qubits(self) -> list[PlaquetteQubit]:
+        return self.syndrome_qubits
+
+    def get_data_qubits_cirq(self) -> list[cirq.GridQubit]:
+        return [q.to_grid_qubit() for q in self.get_data_qubits()]
+
+    def get_syndrome_qubits_cirq(self) -> list[cirq.GridQubit]:
+        return [q.to_grid_qubit() for q in self.get_syndrome_qubits()]
+
+    def __iter__(self):
+        yield from self.data_qubits
+        yield from self.syndrome_qubits
+
+    def to_grid_qubit(self) -> list[cirq.GridQubit]:
+        # GridQubit are indexed as (row, col)
+        return [q.to_grid_qubit() for q in self]
+
+
+class SquarePlaquetteQubits(PlaquetteQubits):
+    def __init__(self):
+        super().__init__(
+            [
+                PlaquetteQubit(Position(-1, -1)),
+                PlaquetteQubit(Position(1, -1)),
+                PlaquetteQubit(Position(-1, 1)),
+                PlaquetteQubit(Position(1, 1)),
+            ],
+            [PlaquetteQubit(Position(0, 0))],
+        )
+
+
+class RoundedPlaquetteQubits(PlaquetteQubits):
+    _POTENTIAL_DATA_QUBITS: ty.Final[list[PlaquetteQubit]] = [
+        PlaquetteQubit(Position(-1, -1)),
+        PlaquetteQubit(Position(1, -1)),
+        PlaquetteQubit(Position(-1, 1)),
+        PlaquetteQubit(Position(1, 1)),
+    ]
+
+    @staticmethod
+    def _get_qubits_on_side(side: PlaquetteSide) -> list[PlaquetteQubit]:
+        data_indices: tuple[int, int]
+        if side == PlaquetteSide.LEFT:
+            data_indices = (0, 2)
+        elif side == PlaquetteSide.RIGHT:
+            data_indices = (1, 3)
+        elif side == PlaquetteSide.UP:
+            data_indices = (0, 1)
+        else:  # if orientation == PlaquetteSide.DOWN:
+            data_indices = (2, 3)
+        return [RoundedPlaquetteQubits._POTENTIAL_DATA_QUBITS[i] for i in data_indices]
+
+    def __init__(self, orientation: PlaquetteOrientation):
+        super().__init__(
+            RoundedPlaquetteQubits._get_qubits_on_side(orientation.to_plaquette_side()),
+            [PlaquetteQubit(Position(0, 0))],
+        )


### PR DESCRIPTION
This PR decouples the `Plaquette` classes from their `qubits`, removing `SquarePlaquette` and `RoundedPlaquette` and allowing the description of higher-level plaquettes with less code duplication.

Fixes #172 