### PR TITLE
Improve plaquette number checking

### DIFF
--- a/src/tqec/templates/base.py
+++ b/src/tqec/templates/base.py
@@ -100,7 +100,7 @@ class Template(JSONEncodable):
         """
         if len(plaquette_indices) < expected_plaquettes_number:
             raise TQECException(
-                f"{self.__class__.__name__}.instanciate needs "
+                f"Calling an instanciate method that requires "
                 f"{expected_plaquettes_number} plaquettes, but only "
                 f"{len(plaquette_indices)} were provided."
             )

--- a/src/tqec/templates/base.py
+++ b/src/tqec/templates/base.py
@@ -90,6 +90,15 @@ class Template(JSONEncodable):
         This method should be called to check that the number of plaquette indices
         provided to the ``instantiate`` method is correct.
 
+        Note:
+            Be warry when calling this method by providing ``self.expected_plaquettes_number``
+            as it is the number of expected plaquettes for the type of the self instance,
+            which might NOT be the same as the number of expected plaquette for the
+            ``instantiate`` method this method is called in (e.g., if a Template subclass `C`
+            is delegating at least part of its ``instantiate`` method to a parent class `P`,
+            ``type(self)`` will always be `C` and ``self.expected_plaquettes_number`` will
+            always be ``C.expected_plaquettes_number``, even if we are within ``S.instantiate``).
+
         Args:
             plaquette_indices: the indices provided to the ``instantiate`` method.
             expected_plaquettes_number: the number of plaquettes expected in

--- a/src/tqec/templates/base.py
+++ b/src/tqec/templates/base.py
@@ -109,7 +109,7 @@ class Template(JSONEncodable):
         """
         if len(plaquette_indices) < expected_plaquettes_number:
             raise TQECException(
-                f"Calling an instanciate method that requires "
+                f"Calling an instantiate method that requires "
                 f"{expected_plaquettes_number} plaquettes, but only "
                 f"{len(plaquette_indices)} were provided."
             )


### PR DESCRIPTION
I do not see a better way of checking the number of plaquettes provided to the `instantiate` method. This PR adds documentation to `Template._check_plaquette_number` to explicitly provide guidance on how to use that method.

Fixes #197 