### PR TITLE
Add GitHub Pages link to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Refer to [this wiki page](https://github.com/QCHackers/tqec/wiki/TQEC-Architectu
 2. [Introduction to TQEC](https://docs.google.com/presentation/d/1RufCoTyPFE0EJfC7fbFMjAyhfNJJKNybaixTFh0Qnfg/edit?usp=sharing)
 3. [Overview of state of the art 2D QEC](https://docs.google.com/presentation/d/1xYBfkVMpA1YEVhpgTZpKvY8zeOO1VyHmRWvx_kDJEU8/edit?usp=sharing)
 4. [Backend deep dive](https://drive.google.com/file/d/1HQEQrln2uVBbs3zbBzrEBm24LDD7PE26/view)
+5. [Developer documentation for the `tqec` project](https://qchackers.github.io/tqec/)
 
 ## Before you commit
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dynamic = ["dependencies"]
 
 [project.urls]
 Website = "https://tqec.app"
+Documentation = "https://qchackers.github.io/tqec/"
 Repository = "https://github.com/QCHackers/tqec"
 Issues = "https://github.com/QCHackers/tqec/issues"
 


### PR DESCRIPTION
This PR adds the newly functional link to the sphinx-generated documentation to:
- the `README.md` file.
- the `pyproject.toml` file, under the name "Documentation"

Fixes #221.

~~It might close (decided that it will not for the moment) #109, but #109 contains a list of points that should be done, and that are not fully done yet.~~