### PR TITLE
Choose orientation for simple `ZXGraph` when converting to `BlockGraph`

### DIFF
--- a/src/tqec/sketchup/block_graph.py
+++ b/src/tqec/sketchup/block_graph.py
@@ -502,11 +502,12 @@ class BlockGraph:
                     bfs_sources.append(corner_cube_in_component)
                     break
             # No corner cube can be found, then choose the orientation
-            # of a non-virtual node in the component
+            # of a non-virtual node with minimum position in the component
             if corner_cube_in_component is None:
+                sorted_positions: list[Position3D] = sorted(component)
                 aligned_node = next(
                     ty.cast(ZXNode, zx_graph.get_node(pos))
-                    for pos in component
+                    for pos in sorted_positions
                     if not ty.cast(ZXNode, zx_graph.get_node(pos)).is_virtual
                 )
                 node_pos, node_type = aligned_node.position, aligned_node.node_type

--- a/src/tqec/sketchup/block_graph_test.py
+++ b/src/tqec/sketchup/block_graph_test.py
@@ -73,13 +73,21 @@ def test_validity_at_turn_color_match() -> None:
 
 
 def test_convert_zx_graph_no_corner() -> None:
-    # Cannot resolve the orientation of a simple idle
     g = ZXGraph("Test ZX Graph Idle")
     g.add_z_node(Position3D(0, 0, 0))
     g.add_z_node(Position3D(0, 0, 1))
     g.add_edge(Position3D(0, 0, 0), Position3D(0, 0, 1))
-    with pytest.raises(TQECException, match="There should be at least one corner node"):
-        g.to_block_graph()
+    bg = g.to_block_graph()
+    assert bg.get_cube(Position3D(0, 0, 0)).cube_type == CubeType.XZZ
+    assert bg.get_cube(Position3D(0, 0, 1)).cube_type == CubeType.XZZ
+
+    g2 = ZXGraph("Horizontal line")
+    g2.add_z_node(Position3D(0, 0, 0))
+    g2.add_x_node(Position3D(1, 0, 0))
+    g2.add_edge(Position3D(0, 0, 0), Position3D(1, 0, 0), has_hadamard=True)
+    bg2 = g2.to_block_graph()
+    assert bg2.get_cube(Position3D(0, 0, 0)).cube_type == CubeType.ZXZ
+    assert bg2.get_cube(Position3D(1, 0, 0)).cube_type == CubeType.XZX
 
 
 def test_convert_zx_graph_roundtrip() -> None:

--- a/src/tqec/sketchup/block_graph_test.py
+++ b/src/tqec/sketchup/block_graph_test.py
@@ -95,7 +95,7 @@ def test_convert_zx_graph_no_corner() -> None:
     assert c3.cube_type == CubeType.ZXZ
     c4 = bg2.get_cube(Position3D(1, 0, 0))
     assert c4 is not None
-    assert c4.cube_type == CubeType.XXZ
+    assert c4.cube_type == CubeType.XZX
 
 
 def test_convert_zx_graph_roundtrip() -> None:

--- a/src/tqec/sketchup/block_graph_test.py
+++ b/src/tqec/sketchup/block_graph_test.py
@@ -78,16 +78,24 @@ def test_convert_zx_graph_no_corner() -> None:
     g.add_z_node(Position3D(0, 0, 1))
     g.add_edge(Position3D(0, 0, 0), Position3D(0, 0, 1))
     bg = g.to_block_graph()
-    assert bg.get_cube(Position3D(0, 0, 0)).cube_type == CubeType.XZZ
-    assert bg.get_cube(Position3D(0, 0, 1)).cube_type == CubeType.XZZ
+    c1 = bg.get_cube(Position3D(0, 0, 0))
+    assert c1 is not None
+    assert c1.cube_type == CubeType.XZZ
+    c2 = bg.get_cube(Position3D(0, 0, 1))
+    assert c2 is not None
+    assert c2.cube_type == CubeType.XZZ
 
     g2 = ZXGraph("Horizontal line")
     g2.add_z_node(Position3D(0, 0, 0))
     g2.add_x_node(Position3D(1, 0, 0))
     g2.add_edge(Position3D(0, 0, 0), Position3D(1, 0, 0), has_hadamard=True)
     bg2 = g2.to_block_graph()
-    assert bg2.get_cube(Position3D(0, 0, 0)).cube_type == CubeType.ZXZ
-    assert bg2.get_cube(Position3D(1, 0, 0)).cube_type == CubeType.XZX
+    c3 = bg2.get_cube(Position3D(0, 0, 0))
+    assert c3 is not None
+    assert c3.cube_type == CubeType.ZXZ
+    c4 = bg2.get_cube(Position3D(1, 0, 0))
+    assert c4 is not None
+    assert c4.cube_type == CubeType.XXZ
 
 
 def test_convert_zx_graph_roundtrip() -> None:


### PR DESCRIPTION
Fix #304 and #308.

When the `ZXGraph` has no corner, the non-virtual node with minimum position will be chosen and the orientation will be selected. The X axis will be intended to align across the spatial X boundares of the cube if possible.