### PR TITLE
Add CI run on Microsoft / MacOS 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.12
+          python-version: '3.12'
           cache: "pip"
       - name: Install dependencies
         run: |
@@ -84,7 +84,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.12
+          python-version: '3.12'
           cache: "pip"
       - name: Install dependencies and tqec package
         run: |

--- a/.github/workflows/exotic-oses.yml
+++ b/.github/workflows/exotic-oses.yml
@@ -1,16 +1,14 @@
 name: exotic-oses
 
 on:
-  # Trigger on PR in order to test within the PR, should be changed
-  # BEFORE merging the PR.
-  pull_request:
+  workflow_run:
+    workflows:
+      - CI
+    types:
+      - completed
     branches:
-      - main
-#   workflow_run:
-#     workflows:
-#       - CI
-#     types:
-#       - completed
+      # - main # << Not yet, test on the specific PR branch for the moment
+      - ci/test-windows-macos
 
 jobs:
   exotic-os-python-tests:

--- a/.github/workflows/exotic-oses.yml
+++ b/.github/workflows/exotic-oses.yml
@@ -1,0 +1,49 @@
+name: exotic-oses
+
+on:
+  # Trigger on PR in order to test within the PR, should be changed
+  # BEFORE merging the PR.
+  pull_request:
+    branches:
+      - main
+#   workflow_run:
+#     workflows:
+#       - CI
+#     types:
+#       - completed
+
+jobs:
+  exotic-os-python-tests:
+    strategy:
+      matrix:
+        os: ["windows-latest", "macos-latest"]
+    runs-on: ${{matrix.os}}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          # Use smallest supported Python version as the common denominator.
+          # In theory, if everything succeed in 3.10, everything should succeed in
+          # 3.11, 3.12 and follow-up version.
+          python-version: 3.10
+          cache: "pip"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt -r requirements-dev.txt
+      - name: Analyze code with pylint
+        run: |
+          python -m pip install pylint
+          pylint $(git ls-files '*.py')
+        continue-on-error: true
+      - name: Build
+        run: python -m pip install '.[all]'
+      - name: Test and coverage
+        run: |
+          python -m pip install pytest pytest-cov
+          python -m pytest --cov=src/tqec $(git ls-files '*_test.py')
+      - name: Mypy type checking
+        run: |
+          python -m pip install mypy
+          python -m mypy src/tqec/

--- a/.github/workflows/exotic-oses.yml
+++ b/.github/workflows/exotic-oses.yml
@@ -26,7 +26,7 @@ jobs:
           # Use smallest supported Python version as the common denominator.
           # In theory, if everything succeed in 3.10, everything should succeed in
           # 3.11, 3.12 and follow-up version.
-          python-version: 3.10
+          python-version: '3.10'
           cache: "pip"
       - name: Install dependencies
         run: |

--- a/.github/workflows/exotic-oses.yml
+++ b/.github/workflows/exotic-oses.yml
@@ -7,8 +7,7 @@ on:
     types:
       - completed
     branches:
-      # - main # << Not yet, test on the specific PR branch for the moment
-      - "ci/test-windows-macos"
+      - main
 
 jobs:
   exotic-os-python-tests:

--- a/.github/workflows/exotic-oses.yml
+++ b/.github/workflows/exotic-oses.yml
@@ -8,7 +8,7 @@ on:
       - completed
     branches:
       # - main # << Not yet, test on the specific PR branch for the moment
-      - ci/test-windows-macos
+      - "ci/test-windows-macos"
 
 jobs:
   exotic-os-python-tests:
@@ -24,7 +24,7 @@ jobs:
           # Use smallest supported Python version as the common denominator.
           # In theory, if everything succeed in 3.10, everything should succeed in
           # 3.11, 3.12 and follow-up version.
-          python-version: '3.10'
+          python-version: "3.10"
           cache: "pip"
       - name: Install dependencies
         run: |

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.12
+          python-version: '3.12'
           cache: "pip"
       - name: Install dependencies
         run: |

--- a/src/tqec/sketchup/collada_test.py
+++ b/src/tqec/sketchup/collada_test.py
@@ -1,3 +1,4 @@
+import os
 import tempfile
 
 import pytest
@@ -38,10 +39,15 @@ def test_logical_cnot_collada_write_read(pipe_length: float) -> None:
 
     block_graph = zx_graph.to_block_graph()
 
-    with tempfile.NamedTemporaryFile(suffix=".dae") as temp_file:
+    # Set `delete=False` to be compatible with Windows
+    # https://docs.python.org/3/library/tempfile.html#tempfile.NamedTemporaryFile
+    with tempfile.NamedTemporaryFile(suffix=".dae", delete=False) as temp_file:
         block_graph.to_dae_file(temp_file.name, pipe_length)
         block_graph_from_file = BlockGraph.from_dae_file(
             temp_file.name, "Logical CNOT Block Graph"
         )
         assert block_graph_from_file == block_graph
         assert block_graph_from_file.to_zx_graph() == zx_graph
+
+    # Manually delete the temporary file
+    os.remove(temp_file.name)


### PR DESCRIPTION
This PR includes installation / test / type analysis on both Windows and MacOS. Because these are more costly than Linux (resp. x2 and x10), I tried to make the workflow run only when everything else succeeded.

Closes #311