### PR TITLE
Fix off-by-1 error in Template display

### DIFF
--- a/src/tqec/templates/display.py
+++ b/src/tqec/templates/display.py
@@ -206,7 +206,7 @@ def display_templates_svg(
     for i, template in enumerate(template_list):
         ul_position = ul_positions[i]
         indices = [
-            plaquette_indices[k]
+            plaquette_indices[k - 1]
             for k in templates._relative_position_graph.nodes[i]["plaquette_indices"]
         ]
         arr = template.instantiate(indices)


### PR DESCRIPTION
This commit fixes an off-by-1 error in an indexing. 

The `plaquette_indices` tuple does **NOT** include the `0` plaquette, so the index should be decreased by 1.