### PR TITLE
Removing FUNDING.yml file

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,0 @@
-github:
-  - smburdick


### PR DESCRIPTION
Sam has been away for a long time and his front-end development is now stale and has been removed from the `main` branch (but still backed up by #326 in https://github.com/QCHackers/tqec/tree/backup/frontend_v1). There is no meaning to have him in the FUNDING.yml file anymore. As with #326, this change might be reverted if work on the front-end is resumed.