### PR TITLE
Adding benchmarks using topological CNOT generation

### DIFF
--- a/examples/benchmarks/bench.sh
+++ b/examples/benchmarks/bench.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+# Exit on error of any of the following lines.
+set -e
+
+usage() {
+    echo "Usage:"
+    echo "\tbench.sh [python file] [value of k]"
+    echo ""
+    echo "Examples:"
+    echo "\tbench.sh cnot_all_observables.py 2"
+}
+
+if [ $# -ne 2 ]
+  then
+    usage
+    exit 1
+fi
+
+PYTHON_EXEC_NAME=$(basename "$1" .py)
+SCALING_FACTOR="$2"
+BENCH_DIRECTORY="data/${PYTHON_EXEC_NAME}_k=${SCALING_FACTOR}_$(date '+%F_%H-%M-%S')"
+
+echo "Saving all benchmark data to ${BENCH_DIRECTORY}"
+mkdir -p $BENCH_DIRECTORY
+
+echo "Statistical profiling of ${PYTHON_EXEC_NAME}.py using pyinstrument..."
+python -m pyinstrument -o "${BENCH_DIRECTORY}/${PYTHON_EXEC_NAME}_k=${SCALING_FACTOR}.html" -r html ${PYTHON_EXEC_NAME}.py -k "$2"
+echo "Profiling saved as an HTML webpage in ${BENCH_DIRECTORY}/${PYTHON_EXEC_NAME}_k=${SCALING_FACTOR}.html"
+
+# echo "Profiling ${PYTHON_EXEC_NAME}.py using cProfile..."
+# python -m cProfile -o "${BENCH_DIRECTORY}/${PYTHON_EXEC_NAME}.pstats" ${PYTHON_EXEC_NAME}.py -k $@
+# echo "cProfile information saved in ${BENCH_DIRECTORY}/${PYTHON_EXEC_NAME}.pstats"
+
+# echo "Generating graphs from profiling report..."
+# python -m flameprof --width 4800 --font-size 10 "${BENCH_DIRECTORY}/${PYTHON_EXEC_NAME}.pstats" > "${BENCH_DIRECTORY}/${PYTHON_EXEC_NAME}_flamegraph.svg"
+# python -m gprof2dot -n 0 -e 0 --depth 2 -f pstats "${BENCH_DIRECTORY}/${PYTHON_EXEC_NAME}.pstats" > "${BENCH_DIRECTORY}/${PYTHON_EXEC_NAME}.dot"
+# dot -Tsvg -o "${BENCH_DIRECTORY}/${PYTHON_EXEC_NAME}_callgraph.svg" < "${BENCH_DIRECTORY}/${PYTHON_EXEC_NAME}.dot"
+# dot -Tpng -o "${BENCH_DIRECTORY}/${PYTHON_EXEC_NAME}_callgraph.png" < "${BENCH_DIRECTORY}/${PYTHON_EXEC_NAME}.dot"

--- a/examples/benchmarks/cnot_all_observables.py
+++ b/examples/benchmarks/cnot_all_observables.py
@@ -1,0 +1,97 @@
+import argparse
+from pathlib import Path
+
+import stim
+
+from tqec.circuit.detectors.construction import annotate_detectors_automatically
+from tqec.compile.compile import CompiledGraph, compile_block_graph
+from tqec.noise_models.after_clifford_depolarization import (
+    AfterCliffordDepolarizingNoise,
+)
+from tqec.noise_models.idle_qubits import DepolarizingNoiseOnIdlingQubit
+from tqec.position import Position3D
+from tqec.sketchup.block_graph import BlockGraph
+from tqec.sketchup.zx_graph import ZXGraph
+
+HERE = Path(__file__).resolve().parent
+BENCHMARK_FOLDER = HERE
+EXAMPLES_FOLDER = HERE.parent
+ASSETS_FOLDER = EXAMPLES_FOLDER / "assets"
+CNOT_DAE_FILE = ASSETS_FOLDER / "logical_cnot.dae"
+
+
+def create_block_graph(from_scratch: bool = False) -> BlockGraph:
+    if not from_scratch:
+        return BlockGraph.from_dae_file(CNOT_DAE_FILE)
+
+    cnot_zx = ZXGraph("Logical CNOT ZX Graph")
+
+    cnot_zx.add_z_node(Position3D(0, 0, 0))
+    cnot_zx.add_x_node(Position3D(0, 0, 1))
+    cnot_zx.add_z_node(Position3D(0, 0, 2))
+    cnot_zx.add_z_node(Position3D(0, 0, 3))
+    cnot_zx.add_x_node(Position3D(0, 1, 1))
+    cnot_zx.add_z_node(Position3D(0, 1, 2))
+    cnot_zx.add_z_node(Position3D(1, 1, 0))
+    cnot_zx.add_z_node(Position3D(1, 1, 1))
+    cnot_zx.add_z_node(Position3D(1, 1, 2))
+    cnot_zx.add_z_node(Position3D(1, 1, 3))
+
+    cnot_zx.add_edge(Position3D(0, 0, 0), Position3D(0, 0, 1))
+    cnot_zx.add_edge(Position3D(0, 0, 1), Position3D(0, 0, 2))
+    cnot_zx.add_edge(Position3D(0, 0, 2), Position3D(0, 0, 3))
+    cnot_zx.add_edge(Position3D(0, 0, 1), Position3D(0, 1, 1))
+    cnot_zx.add_edge(Position3D(0, 1, 1), Position3D(0, 1, 2))
+    cnot_zx.add_edge(Position3D(0, 1, 2), Position3D(1, 1, 2))
+    cnot_zx.add_edge(Position3D(1, 1, 0), Position3D(1, 1, 1))
+    cnot_zx.add_edge(Position3D(1, 1, 1), Position3D(1, 1, 2))
+    cnot_zx.add_edge(Position3D(1, 1, 2), Position3D(1, 1, 3))
+    return cnot_zx.to_block_graph("Logical CNOT Block Graph")
+
+
+def generate_stim_circuit(
+    compiled_graph: CompiledGraph, k: int, p: float
+) -> stim.Circuit:
+    circuit_without_detectors = compiled_graph.generate_stim_circuit(
+        k,
+        noise_models=[
+            AfterCliffordDepolarizingNoise(p),
+            DepolarizingNoiseOnIdlingQubit(p),
+        ],
+    )
+    # For now, we annotate the detectors as post-processing step
+    return annotate_detectors_automatically(circuit_without_detectors)
+
+
+def generate_cnot_circuits(*ks: int):
+    # 1 Create `BlockGraph` representing the computation
+    block_graph = create_block_graph(from_scratch=False)
+
+    # 2. (Optional) Find and choose the logical observables
+    observables = block_graph.get_abstract_observables()
+
+    # 3. Compile the `BlockGraph`
+    compiled_graph = compile_block_graph(
+        block_graph,
+        observables=[observables[1]],
+    )
+
+    for k in ks:
+        _ = generate_stim_circuit(compiled_graph, k, 0.001)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="")
+    parser.add_argument(
+        "-k",
+        help="The scale factors applied to the circuits.",
+        nargs="+",
+        type=int,
+        required=True,
+    )
+    args = parser.parse_args()
+    generate_cnot_circuits(*args.k)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,8 @@ Issues = "https://github.com/QCHackers/tqec/issues"
 test = ["pytest", "mypy", "pytest-cov"]
 dev = ["sinter", "pymatching", "jupyterlab", "tqec[test, doc]", "pre-commit"]
 doc = ["sphinx", "myst-parser", "sphinx-rtd-theme", "nbsphinx", "pandoc"]
-all = ["tqec[test, dev, doc]"]
+bench = ["pyinstrument"]
+all = ["tqec[test, dev, doc, bench]"]
 
 [project.scripts]
 tqec = "tqec._cli.tqec:main"


### PR DESCRIPTION
This PR fixes #328 by adding a few files to benchmark the runtime of the `tqec` library to generate a fully annotated (detectors and observables) `stim` file from a `.dae` file and a scaling factor `k`.

To start a benchmark:

```bash
cd examples/benchmarks/
# Usage: ./bench.sh [python file to benchmark] [scaling factor k]
./bench.sh cnot_all_observables.py 2
```

This should output something along the lines of

```
Saving all benchmark data to data/cnot_all_observables_k=2_2024-10-03_13-02-42
Statistical profiling of cnot_all_observables.py using pyinstrument...
Profiling saved as an HTML webpage in data/cnot_all_observables_k=2_2024-10-03_13-02-42/cnot_all_observables_k=2.html
```

and you will be able to open the benchmark data by opening the static and self-contained HTML file generated.