### PR TITLE
Avoid storing `k` in `Template` instances

### DIFF
--- a/src/tqec/circuit/generation.py
+++ b/src/tqec/circuit/generation.py
@@ -32,7 +32,9 @@ from tqec.position import Displacement
 from tqec.templates.base import Template
 
 
-def generate_circuit(template: Template, plaquettes: Plaquettes) -> ScheduledCircuit:
+def generate_circuit(
+    template: Template, k: int, plaquettes: Plaquettes
+) -> ScheduledCircuit:
     """Generate a quantum circuit from a template and its plaquettes.
 
     This is one of the core methods of the `tqec` package. It generates a
@@ -53,6 +55,7 @@ def generate_circuit(template: Template, plaquettes: Plaquettes) -> ScheduledCir
     Args:
         template: spatial description of the quantum error correction experiment
             we want to implement.
+        k: scaling parameter used to instantiate the provided `template`.
         plaquettes: description of the computation that should happen at
             different time-slices of the quantum error correction experiment (or
             at least part of it).
@@ -77,7 +80,7 @@ def generate_circuit(template: Template, plaquettes: Plaquettes) -> ScheduledCir
     # instantiate the template with the appropriate plaquette indices.
     # Index 0 is "no plaquette" by convention and should not be included here.
     _indices = list(range(1, template.expected_plaquettes_number + 1))
-    template_plaquettes = template.instantiate(_indices)
+    template_plaquettes = template.instantiate(k, _indices)
     increments = template.get_increments()
 
     return generate_circuit_from_instantiation(

--- a/src/tqec/circuit/generation_test.py
+++ b/src/tqec/circuit/generation_test.py
@@ -47,7 +47,7 @@ def _expected_circuit() -> stim.Circuit:
 def test_generate_circuit_dict(
     plaquette: Plaquette, one_by_one_template: Template
 ) -> None:
-    circuit = generate_circuit(one_by_one_template, Plaquettes({1: plaquette}))
+    circuit = generate_circuit(one_by_one_template, 2, Plaquettes({1: plaquette}))
     assert circuit.get_circuit() == _expected_circuit()
 
 
@@ -55,7 +55,7 @@ def test_generate_circuit_defaultdict(
     plaquette: Plaquette, one_by_one_template: Template
 ) -> None:
     circuit = generate_circuit(
-        one_by_one_template, Plaquettes(defaultdict(lambda: plaquette))
+        one_by_one_template, 2, Plaquettes(defaultdict(lambda: plaquette))
     )
     assert circuit.get_circuit() == _expected_circuit()
 
@@ -64,13 +64,15 @@ def test_generate_circuit_dict_0_indexed(
     plaquette: Plaquette, one_by_one_template: Template
 ) -> None:
     with pytest.raises(TQECException):
-        generate_circuit(one_by_one_template, Plaquettes({0: plaquette}))
+        generate_circuit(one_by_one_template, 2, Plaquettes({0: plaquette}))
 
 
 def test_generate_circuit_wrong_number_of_plaquettes(
     plaquette: Plaquette, one_by_one_template: Template
 ) -> None:
     with pytest.raises(TQECException):
-        generate_circuit(one_by_one_template, Plaquettes({1: plaquette, 2: plaquette}))
+        generate_circuit(
+            one_by_one_template, 2, Plaquettes({1: plaquette, 2: plaquette})
+        )
     with pytest.raises(TQECException):
-        generate_circuit(one_by_one_template, Plaquettes({}))
+        generate_circuit(one_by_one_template, 2, Plaquettes({}))

--- a/src/tqec/circuit/observable_qubits.py
+++ b/src/tqec/circuit/observable_qubits.py
@@ -12,6 +12,7 @@ from tqec.templates.enums import TemplateOrientation
 
 def observable_qubits_from_template(
     template: Template,
+    k: int,
     plaquettes: Sequence[Plaquette] | Mapping[int, Plaquette],
     orientation: TemplateOrientation = TemplateOrientation.HORIZONTAL,
 ) -> Sequence[tuple[GridQubit, int]]:
@@ -20,6 +21,7 @@ def observable_qubits_from_template(
 
     Args:
         template: The template to get the default observable qubits from.
+        k: scaling parameter used to instantiate the provided template.
         plaquettes: The plaquettes to use to get the accurate positions of the observable qubits.
         orientation: Whether to get the observable qubits from
             the horizontal or vertical midline. Defaults to horizontal.
@@ -47,11 +49,11 @@ def observable_qubits_from_template(
         plaquettes = {i + 1: plaquette for i, plaquette in enumerate(plaquettes)}
 
     _indices = list(range(1, len(plaquettes) + 1))
-    template_plaquettes = template.instantiate(_indices)
+    template_plaquettes = template.instantiate(k, _indices)
     increments = template.get_increments()
 
     try:
-        midline_indices = template.get_midline_plaquettes(orientation)
+        midline_indices = template.get_midline_plaquettes(k, orientation)
     except TQECException as e:
         raise TQECException(
             "The template does not have a midline. "

--- a/src/tqec/circuit/observable_qubits_test.py
+++ b/src/tqec/circuit/observable_qubits_test.py
@@ -26,7 +26,7 @@ def test_raw_rectangle_default_observable_qubits(plaquettes: list[Plaquette]) ->
         ]
     )
 
-    obs = observable_qubits_from_template(template, plaquettes)
+    obs = observable_qubits_from_template(template, 1, plaquettes)
     result = [
         (GridQubit(-1, 3), 0),
         (GridQubit(1, 3), 0),

--- a/src/tqec/compile/block.py
+++ b/src/tqec/compile/block.py
@@ -118,19 +118,15 @@ class BlockLayout:
             merged_layers.append(plaquettes)
         return merged_layers
 
-    def scale_to(self, k: int) -> None:
-        """Scales all the blocks in the layout to the given factor."""
-        self._template.scale_to(k)
-
     @property
     def num_layers(self) -> int:
         return len(self._layers)
 
-    def instantiate_layer(self, layer_index: int) -> ScheduledCircuit:
+    def instantiate_layer(self, layer_index: int, k: int) -> ScheduledCircuit:
         """Instantiates the specified layer into a `ScheduledCircuit`.
 
         Note that this method does not shift the circuits based on the
         layout template. And the circuits are not repeated based on the
         repetitions in the layer.
         """
-        return generate_circuit(self._template, self._layers[layer_index])
+        return generate_circuit(self._template, k, self._layers[layer_index])

--- a/src/tqec/compile/observables.py
+++ b/src/tqec/compile/observables.py
@@ -2,10 +2,10 @@ import stim
 
 from tqec.circuit.qubit import GridQubit
 from tqec.circuit.schedule import ScheduledCircuit
+from tqec.computation.block_graph import AbstractObservable, Cube, Pipe
 from tqec.exceptions import TQECException
 from tqec.position import Direction3D, Displacement, Shape2D
 from tqec.scale import round_or_fail
-from tqec.computation.block_graph import AbstractObservable, Cube, Pipe
 from tqec.templates.layout import LayoutTemplate
 
 
@@ -131,6 +131,7 @@ def inplace_add_observables(
     circuits: list[list[ScheduledCircuit]],
     template_slices: list[LayoutTemplate],
     abstract_observables: list[AbstractObservable],
+    k: int,
 ) -> None:
     """Inplace add the observable components to the circuits.
 
@@ -143,7 +144,7 @@ def inplace_add_observables(
             z = pipe.u.position.z
             template = template_slices[z]
             stabilizer_qubits = get_stabilizer_region_qubits_for_pipe(
-                pipe, template.element_shape, template.get_increments()
+                pipe, template.element_shape(k), template.get_increments()
             )
             measurement_records = _get_measurement_records_from_scheduled_circuit(
                 circuits[z][0]
@@ -162,14 +163,16 @@ def inplace_add_observables(
                 z = cube_or_pipe.position.z
                 template = template_slices[z]
                 qubits = get_midline_qubits_for_cube(
-                    cube_or_pipe, template.element_shape, template.get_increments()
+                    cube_or_pipe, template.element_shape(k), template.get_increments()
                 )
             else:
                 z = cube_or_pipe.u.position.z
                 template = template_slices[z]
                 qubits = [
                     get_center_qubit_at_horizontal_pipe(
-                        cube_or_pipe, template.element_shape, template.get_increments()
+                        cube_or_pipe,
+                        template.element_shape(k),
+                        template.get_increments(),
                     )
                 ]
             measurement_records = _get_measurement_records_from_scheduled_circuit(

--- a/src/tqec/templates/_testing.py
+++ b/src/tqec/templates/_testing.py
@@ -16,17 +16,16 @@ class FixedTemplate(RectangularTemplate):
     def __init__(
         self,
         indices: Sequence[Sequence[int]],
-        k: int = 2,
         default_increments: Displacement | None = None,
     ) -> None:
-        super().__init__(k, default_increments)
+        super().__init__(default_increments)
         self._indices: npt.NDArray[numpy.int_] = numpy.array(
             [list(line) for line in indices]
         )
 
     @override
     def instantiate(
-        self, plaquette_indices: Sequence[int] | None = None
+        self, _: int = 0, plaquette_indices: Sequence[int] | None = None
     ) -> npt.NDArray[numpy.int_]:
         if plaquette_indices is None:
             plaquette_indices = list(range(1, self.expected_plaquettes_number + 1))

--- a/src/tqec/templates/_testing_test.py
+++ b/src/tqec/templates/_testing_test.py
@@ -13,11 +13,16 @@ def test_construction() -> None:
 
 
 def test_instantiation() -> None:
-    numpy.testing.assert_array_equal(FixedTemplate([[0]]).instantiate([1]), [[1]])
-    numpy.testing.assert_array_equal(FixedTemplate([[0]]).instantiate(), [[1]])
-    numpy.testing.assert_array_equal(FixedTemplate([[1]]).instantiate([1, 2]), [[2]])
     numpy.testing.assert_array_equal(
-        FixedTemplate([[0, 1], [1, 2]]).instantiate([1, 2, 3]), [[1, 2], [2, 3]]
+        FixedTemplate([[0]]).instantiate(plaquette_indices=[1]), [[1]]
+    )
+    numpy.testing.assert_array_equal(FixedTemplate([[0]]).instantiate(), [[1]])
+    numpy.testing.assert_array_equal(
+        FixedTemplate([[1]]).instantiate(plaquette_indices=[1, 2]), [[2]]
+    )
+    numpy.testing.assert_array_equal(
+        FixedTemplate([[0, 1], [1, 2]]).instantiate(plaquette_indices=[1, 2, 3]),
+        [[1, 2], [2, 3]],
     )
 
 
@@ -25,7 +30,7 @@ def test_shape() -> None:
     assert FixedTemplate([[0]]).scalable_shape == Scalable2D(
         LinearFunction(0, 1), LinearFunction(0, 1)
     )
-    assert FixedTemplate([[0]]).shape == Shape2D(1, 1)
+    assert FixedTemplate([[0]]).shape(1) == Shape2D(1, 1)
 
 
 def test_number_of_expected_plaquettes() -> None:

--- a/src/tqec/templates/display.py
+++ b/src/tqec/templates/display.py
@@ -9,7 +9,7 @@ from tqec.templates.base import Template
 
 
 def display_template(
-    template: Template, plaquette_indices: ty.Sequence[int] | None = None
+    template: Template, k: int, plaquette_indices: ty.Sequence[int] | None = None
 ) -> None:
     """Display a template instance with ASCII output.
 
@@ -21,7 +21,7 @@ def display_template(
     """
     if plaquette_indices is None:
         plaquette_indices = tuple(range(1, template.expected_plaquettes_number + 1))
-    display_template_from_instantiation(template.instantiate(plaquette_indices))
+    display_template_from_instantiation(template.instantiate(k, plaquette_indices))
 
 
 def display_template_from_instantiation(instantiation: npt.NDArray[numpy.int_]) -> None:

--- a/src/tqec/templates/qubit.py
+++ b/src/tqec/templates/qubit.py
@@ -26,12 +26,12 @@ class QubitTemplate(RectangularTemplate):
 
     @override
     def instantiate(
-        self, plaquette_indices: Sequence[int] | None = None
+        self, k: int, plaquette_indices: Sequence[int] | None = None
     ) -> npt.NDArray[numpy.int_]:
         if plaquette_indices is None:
             plaquette_indices = list(range(1, self.expected_plaquettes_number + 1))
 
-        ret = numpy.zeros(self.shape.to_numpy_shape(), dtype=numpy.int_)
+        ret = numpy.zeros(self.shape(k).to_numpy_shape(), dtype=numpy.int_)
 
         # The four corners
         ret[0, 0] = plaquette_indices[0]
@@ -108,12 +108,12 @@ class QubitVerticalBorders(RectangularTemplate):
 
     @override
     def instantiate(
-        self, plaquette_indices: Sequence[int] | None = None
+        self, k: int, plaquette_indices: Sequence[int] | None = None
     ) -> npt.NDArray[numpy.int_]:
         if plaquette_indices is None:
             plaquette_indices = list(range(1, self.expected_plaquettes_number + 1))
 
-        ret = numpy.zeros(self.shape.to_numpy_shape(), dtype=numpy.int_)
+        ret = numpy.zeros(self.shape(k).to_numpy_shape(), dtype=numpy.int_)
 
         # The four corners
         ret[0, 0] = plaquette_indices[0]
@@ -176,12 +176,12 @@ class QubitHorizontalBorders(RectangularTemplate):
 
     @override
     def instantiate(
-        self, plaquette_indices: Sequence[int] | None = None
+        self, k: int, plaquette_indices: Sequence[int] | None = None
     ) -> npt.NDArray[numpy.int_]:
         if plaquette_indices is None:
             plaquette_indices = list(range(1, self.expected_plaquettes_number + 1))
 
-        ret = numpy.zeros(self.shape.to_numpy_shape(), dtype=numpy.int_)
+        ret = numpy.zeros(self.shape(k).to_numpy_shape(), dtype=numpy.int_)
 
         # The four corners
         ret[0, 0] = plaquette_indices[0]
@@ -256,12 +256,12 @@ class Qubit4WayJunctionTemplate(RectangularTemplate):
 
     @override
     def instantiate(
-        self, plaquette_indices: Sequence[int] | None = None
+        self, k: int, plaquette_indices: Sequence[int] | None = None
     ) -> npt.NDArray[numpy.int_]:
         if plaquette_indices is None:
             plaquette_indices = list(range(1, self.expected_plaquettes_number + 1))
 
-        if self.k == 1:
+        if k == 1:
             warnings.warn(
                 "Instantiating Qubit4WayJunctionTemplate with k=1. The "
                 "instantiation array returned will not have any plaquette indexed "
@@ -269,8 +269,9 @@ class Qubit4WayJunctionTemplate(RectangularTemplate):
                 TQECWarning,
             )
 
-        ret = numpy.zeros(self.shape.to_numpy_shape(), dtype=numpy.int_)
-        size = self.shape.x
+        shape = self.shape(k)
+        ret = numpy.zeros(shape.to_numpy_shape(), dtype=numpy.int_)
+        size = shape.x
 
         # The four corners
         ret[0, 0] = plaquette_indices[0]

--- a/src/tqec/templates/qubit_test.py
+++ b/src/tqec/templates/qubit_test.py
@@ -12,22 +12,11 @@ from tqec.templates.qubit import (
 )
 
 
-@pytest.mark.parametrize(
-    "tested_class",
-    [
-        QubitTemplate,
-        QubitHorizontalBorders,
-        QubitVerticalBorders,
-        Qubit4WayJunctionTemplate,
-    ],
-)
-def test_creation(tested_class: type) -> None:
-    tested_class()
-    tested_class(k=10000)
-    with pytest.raises(
-        TQECException, match=r"^Cannot have a negative scaling parameter. Got -1.$"
-    ):
-        tested_class(k=-1)
+def test_creation() -> None:
+    QubitTemplate()
+    QubitHorizontalBorders()
+    QubitVerticalBorders()
+    Qubit4WayJunctionTemplate()
 
 
 def test_expected_plaquettes_number() -> None:
@@ -53,9 +42,9 @@ def test_scalable_shape() -> None:
 
 
 def test_qubit_template_instantiation() -> None:
-    template = QubitTemplate(k=2)
+    template = QubitTemplate()
     numpy.testing.assert_array_equal(
-        template.instantiate(),
+        template.instantiate(2),
         [
             [1, 5, 6, 5, 6, 2],
             [7, 9, 10, 9, 10, 11],
@@ -65,9 +54,8 @@ def test_qubit_template_instantiation() -> None:
             [3, 13, 14, 13, 14, 4],
         ],
     )
-    template.scale_to(4)
     numpy.testing.assert_array_equal(
-        template.instantiate(),
+        template.instantiate(4),
         [
             [1, 5, 6, 5, 6, 5, 6, 5, 6, 2],
             [7, 9, 10, 9, 10, 9, 10, 9, 10, 11],
@@ -84,9 +72,9 @@ def test_qubit_template_instantiation() -> None:
 
 
 def test_qubit_vertical_borders_template_instantiation() -> None:
-    template = QubitVerticalBorders(k=2)
+    template = QubitVerticalBorders()
     numpy.testing.assert_array_equal(
-        template.instantiate(),
+        template.instantiate(2),
         [
             [1, 2],
             [5, 7],
@@ -96,9 +84,8 @@ def test_qubit_vertical_borders_template_instantiation() -> None:
             [3, 4],
         ],
     )
-    template.scale_to(4)
     numpy.testing.assert_array_equal(
-        template.instantiate(),
+        template.instantiate(4),
         [
             [1, 2],
             [5, 7],
@@ -115,17 +102,16 @@ def test_qubit_vertical_borders_template_instantiation() -> None:
 
 
 def test_qubit_horizontal_borders_template_instantiation() -> None:
-    template = QubitHorizontalBorders(k=2)
+    template = QubitHorizontalBorders()
     numpy.testing.assert_array_equal(
-        template.instantiate(),
+        template.instantiate(2),
         [
             [1, 5, 6, 5, 6, 2],
             [3, 7, 8, 7, 8, 4],
         ],
     )
-    template.scale_to(4)
     numpy.testing.assert_array_equal(
-        template.instantiate(),
+        template.instantiate(4),
         [
             [1, 5, 6, 5, 6, 5, 6, 5, 6, 2],
             [3, 7, 8, 7, 8, 7, 8, 7, 8, 4],
@@ -134,7 +120,7 @@ def test_qubit_horizontal_borders_template_instantiation() -> None:
 
 
 def test_qubit_4_way_junction_template_instantiation() -> None:
-    template = Qubit4WayJunctionTemplate(k=1)
+    template = Qubit4WayJunctionTemplate()
 
     expected_warning_message = (
         "Instantiating Qubit4WayJunctionTemplate with k=1. The "
@@ -143,7 +129,7 @@ def test_qubit_4_way_junction_template_instantiation() -> None:
     )
     with pytest.warns(TQECWarning, match=expected_warning_message):
         numpy.testing.assert_array_equal(
-            template.instantiate(),
+            template.instantiate(1),
             [
                 [1, 5, 6, 2],
                 [7, 10, 11, 12],
@@ -151,9 +137,8 @@ def test_qubit_4_way_junction_template_instantiation() -> None:
                 [3, 14, 15, 4],
             ],
         )
-    template.scale_to(2)
     numpy.testing.assert_array_equal(
-        template.instantiate(),
+        template.instantiate(2),
         [
             [1, 5, 6, 5, 6, 2],
             [7, 10, 11, 10, 11, 12],


### PR DESCRIPTION
Managing the scaling parameter `k` in `Template` instances is not needed at all, in fact `k` can just be provided to the functions that need it.

This is less error-prone as we do not have to manage scaling parameters that should be kept in-sync.