### PR TITLE
Require `python<3.13` and add `typing-extensions` to requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ description = "A design automation framework for Topological Quantum Error Corre
 readme = "README.md"
 license = { file = "LICENSE" }
 keywords = ["topological quantum error correction", "qec"]
-requires-python = ">= 3.10, <3.13"
+requires-python = ">= 3.10"
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ description = "A design automation framework for Topological Quantum Error Corre
 readme = "README.md"
 license = { file = "LICENSE" }
 keywords = ["topological quantum error correction", "qec"]
-requires-python = ">= 3.10"
+requires-python = ">= 3.10, <3.13"
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,6 @@ numpy
 networkx
 stim
 pycollada
+typing-extensions
 pycryptosat!=5.11.23
 python-sat[cryptosat]


### PR DESCRIPTION
Fix #363 

From @nelimee:

> - When trying to install tqec, I had an issue due to Python 3.13 being the newest Python version but most of our dependencies (and in particular stim) do not have yet pre-built binaries, leading to some issues related to CPython imports in stim.
> 
> - The `typing-extensions` package seems to be missing from our requirements. I though it was a standard python package, it seems like this is not the case. 