### PR TITLE
Add name to `Plaquette`

### DIFF
--- a/src/tqec/plaquette/library/css_test.py
+++ b/src/tqec/plaquette/library/css_test.py
@@ -13,6 +13,7 @@ from tqec.plaquette.qubit import PlaquetteQubits, SquarePlaquetteQubits
 def test_css_surface_code_memory_plaquette() -> None:
     plaquette = make_css_surface_code_plaquette("X")
     assert plaquette.qubits == SquarePlaquetteQubits()
+    assert plaquette.name == "CSS_basis(X)_VERTICAL"
     circuit = plaquette.circuit.get_circuit()
     assert circuit.has_flow(stim.Flow("1 -> _XXXX xor rec[-1]"))
     assert circuit.has_flow(stim.Flow("_XXXX -> 1 xor rec[-1]"))
@@ -35,6 +36,7 @@ TICK
 MX 0
 """)
     plaquette = make_css_surface_code_plaquette("Z")
+    assert plaquette.name == "CSS_basis(Z)_VERTICAL"
     circuit = plaquette.circuit.get_circuit()
     assert circuit.has_flow(stim.Flow("1 -> _ZZZZ xor rec[-1]"))
     assert circuit.has_flow(stim.Flow("_ZZZZ -> 1 xor rec[-1]"))
@@ -59,6 +61,7 @@ M 0
     plaquette = make_css_surface_code_plaquette(
         "X", x_boundary_orientation="HORIZONTAL"
     )
+    assert plaquette.name == "CSS_basis(X)_HORIZONTAL"
     circuit = plaquette.circuit.get_circuit()
     assert circuit.has_flow(stim.Flow("1 -> _XXXX xor rec[-1]"))
     assert circuit.has_flow(stim.Flow("_XXXX -> 1 xor rec[-1]"))
@@ -83,6 +86,7 @@ MX 0
     plaquette = make_css_surface_code_plaquette(
         "Z", x_boundary_orientation="HORIZONTAL"
     )
+    assert plaquette.name == "CSS_basis(Z)_HORIZONTAL"
     circuit = plaquette.circuit.get_circuit()
     assert circuit.has_flow(stim.Flow("1 -> _ZZZZ xor rec[-1]"))
     assert circuit.has_flow(stim.Flow("_ZZZZ -> 1 xor rec[-1]"))
@@ -108,6 +112,7 @@ M 0
 
 def test_css_surface_code_init_meas_plaquette() -> None:
     plaquette = make_css_surface_code_plaquette("Z", ResetBasis.Z, MeasurementBasis.Z)
+    assert plaquette.name == "CSS_basis(Z)_VERTICAL_datainit(Z)_datameas(Z)"
     circuit = plaquette.circuit.get_circuit()
     assert circuit.has_flow(
         stim.Flow("1 -> 1 xor rec[-1] xor rec[-2] xor rec[-3] xor rec[-4] xor rec[-5]")
@@ -131,6 +136,7 @@ TICK
 M 0 1 2 3 4
 """)
     plaquette = make_css_surface_code_plaquette("X", ResetBasis.X, MeasurementBasis.X)
+    assert plaquette.name == "CSS_basis(X)_VERTICAL_datainit(X)_datameas(X)"
     circuit = plaquette.circuit.get_circuit()
     assert circuit.has_flow(
         stim.Flow("1 -> 1 xor rec[-1] xor rec[-2] xor rec[-3] xor rec[-4] xor rec[-5]")
@@ -157,8 +163,10 @@ MX 0 1 2 3 4
 
 def test_css_surface_code_projected_plaquette() -> None:
     plaquette = make_css_surface_code_plaquette("X")
+    assert plaquette.name == "CSS_basis(X)_VERTICAL"
     qubits = plaquette.qubits
     plaquette_up = plaquette.project_on_boundary(PlaquetteOrientation.UP)
+    assert plaquette_up.name == "CSS_basis(X)_VERTICAL_UP"
     assert plaquette_up.qubits == PlaquetteQubits(
         data_qubits=qubits.get_qubits_on_side(PlaquetteSide.DOWN),
         syndrome_qubits=qubits.syndrome_qubits,
@@ -180,6 +188,7 @@ TICK
 MX 0
 """)
     plaquette_down = plaquette.project_on_boundary(PlaquetteOrientation.DOWN)
+    assert plaquette_down.name == "CSS_basis(X)_VERTICAL_DOWN"
     assert plaquette_down.qubits == PlaquetteQubits(
         data_qubits=qubits.get_qubits_on_side(PlaquetteSide.UP),
         syndrome_qubits=qubits.syndrome_qubits,
@@ -201,6 +210,7 @@ TICK
 MX 0
 """)
     plaquette_left = plaquette.project_on_boundary(PlaquetteOrientation.LEFT)
+    assert plaquette_left.name == "CSS_basis(X)_VERTICAL_LEFT"
     assert plaquette_left.qubits == PlaquetteQubits(
         data_qubits=qubits.get_qubits_on_side(PlaquetteSide.RIGHT),
         syndrome_qubits=qubits.syndrome_qubits,
@@ -222,6 +232,7 @@ TICK
 MX 0
 """)
     plaquette_right = plaquette.project_on_boundary(PlaquetteOrientation.RIGHT)
+    assert plaquette_right.name == "CSS_basis(X)_VERTICAL_RIGHT"
     assert plaquette_right.qubits == PlaquetteQubits(
         data_qubits=qubits.get_qubits_on_side(PlaquetteSide.LEFT),
         syndrome_qubits=qubits.syndrome_qubits,
@@ -250,6 +261,7 @@ def test_css_surface_code_init_meas_only() -> None:
         data_initialization=ResetBasis.X,
         init_meas_only_on_side=PlaquetteSide.RIGHT,
     )
+    assert plaquette.name == "CSS_basis(X)_VERTICAL_datainit(X,RIGHT)"
     circuit = plaquette.circuit.get_circuit()
     assert circuit == stim.Circuit("""
 QUBIT_COORDS(0, 0) 0
@@ -274,6 +286,7 @@ MX 0
         data_measurement=MeasurementBasis.Z,
         init_meas_only_on_side=PlaquetteSide.UP,
     )
+    assert plaquette.name == "CSS_basis(Z)_VERTICAL_datameas(Z,UP)"
     circuit = plaquette.circuit.get_circuit()
     assert circuit == stim.Circuit("""
 QUBIT_COORDS(0, 0) 0

--- a/src/tqec/plaquette/library/empty.py
+++ b/src/tqec/plaquette/library/empty.py
@@ -10,7 +10,7 @@ from tqec.plaquette.qubit import (
 
 
 def empty_plaquette(qubits: PlaquetteQubits) -> Plaquette:
-    return Plaquette(qubits, ScheduledCircuit.empty())
+    return Plaquette("empty", qubits, ScheduledCircuit.empty())
 
 
 def empty_square_plaquette() -> Plaquette:

--- a/src/tqec/plaquette/library/zxxz_test.py
+++ b/src/tqec/plaquette/library/zxxz_test.py
@@ -13,6 +13,7 @@ from tqec.plaquette.qubit import PlaquetteQubits, SquarePlaquetteQubits
 def test_zxxz_surface_code_memory_plaquette() -> None:
     plaquette = make_zxxz_surface_code_plaquette("X")
     assert plaquette.qubits == SquarePlaquetteQubits()
+    assert plaquette.name == "ZXXZ_basis(X)_VERTICAL"
     assert "H" in plaquette.mergeable_instructions
     circuit = plaquette.circuit.get_circuit()
     assert circuit.has_flow(stim.Flow("_ZXXZ -> Z____"))
@@ -46,6 +47,7 @@ M 0
 
     plaquette = make_zxxz_surface_code_plaquette("Z")
     assert plaquette.qubits == SquarePlaquetteQubits()
+    assert plaquette.name == "ZXXZ_basis(Z)_VERTICAL"
     circuit = plaquette.circuit.get_circuit()
     assert circuit.has_flow(stim.Flow("_ZXXZ -> Z____"))
     assert circuit.has_flow(stim.Flow("1 -> _ZXXZ xor rec[-1]"))
@@ -79,6 +81,7 @@ M 0
     plaquette = make_zxxz_surface_code_plaquette(
         "X", x_boundary_orientation="HORIZONTAL"
     )
+    assert plaquette.name == "ZXXZ_basis(X)_HORIZONTAL"
     circuit = plaquette.circuit.get_circuit()
     assert circuit.has_flow(stim.Flow("_XZZX -> Z____"))
     assert circuit.has_flow(stim.Flow("1 -> _XZZX xor rec[-1]"))
@@ -116,6 +119,7 @@ def test_zxxz_surface_code_init_meas_plaquette() -> None:
         ResetBasis.Z,
         MeasurementBasis.Z,
     )
+    assert plaquette.name == "ZXXZ_basis(Z)_VERTICAL_datainit(Z)_datameas(Z)"
     circuit = plaquette.circuit.get_circuit()
     assert circuit.has_flow(
         stim.Flow("1 -> 1 xor rec[-1] xor rec[-2] xor rec[-3] xor rec[-4] xor rec[-5]")
@@ -151,6 +155,7 @@ M 0 1 2 3 4
         ResetBasis.X,
         MeasurementBasis.X,
     )
+    assert plaquette.name == "ZXXZ_basis(X)_VERTICAL_datainit(X)_datameas(X)"
     circuit = plaquette.circuit.get_circuit()
     assert circuit.has_flow(
         stim.Flow("1 -> 1 xor rec[-1] xor rec[-2] xor rec[-3] xor rec[-4] xor rec[-5]")
@@ -188,6 +193,9 @@ M 0 1 2 3 4
         x_boundary_orientation="HORIZONTAL",
         init_meas_only_on_side=PlaquetteSide.RIGHT,
     )
+    assert (
+        plaquette.name == "ZXXZ_basis(Z)_HORIZONTAL_datainit(Z,RIGHT)_datameas(Z,RIGHT)"
+    )
     circuit = plaquette.circuit.get_circuit()
     assert circuit.has_flow(stim.Flow("1 -> _Z_X_ xor rec[-1] xor rec[-2] xor rec[-3]"))
     assert circuit == stim.Circuit("""
@@ -220,12 +228,14 @@ M 0 2 4
 
 def test_zxxz_surface_code_projected_plaquette() -> None:
     plaquette = make_zxxz_surface_code_plaquette("X", ResetBasis.X, MeasurementBasis.X)
+    assert plaquette.name == "ZXXZ_basis(X)_VERTICAL_datainit(X)_datameas(X)"
     qubits = plaquette.qubits
     plaquette_up = plaquette.project_on_boundary(PlaquetteOrientation.UP)
     assert plaquette_up.qubits == PlaquetteQubits(
         data_qubits=qubits.get_qubits_on_side(PlaquetteSide.DOWN),
         syndrome_qubits=qubits.syndrome_qubits,
     )
+    assert plaquette_up.name == "ZXXZ_basis(X)_VERTICAL_datainit(X)_datameas(X)_UP"
     circuit = plaquette_up.circuit.get_circuit()
     assert circuit.has_flow(stim.Flow("1 -> 1 xor rec[-1] xor rec[-2] xor rec[-3]"))
     assert circuit == stim.Circuit("""
@@ -251,6 +261,7 @@ TICK
 M 0 1 2
 """)
     plaquette_down = plaquette.project_on_boundary(PlaquetteOrientation.DOWN)
+    assert plaquette_down.name == "ZXXZ_basis(X)_VERTICAL_datainit(X)_datameas(X)_DOWN"
     assert plaquette_down.qubits == PlaquetteQubits(
         data_qubits=qubits.get_qubits_on_side(PlaquetteSide.UP),
         syndrome_qubits=qubits.syndrome_qubits,
@@ -280,6 +291,7 @@ TICK
 M 0 1 2
 """)
     plaquette_left = plaquette.project_on_boundary(PlaquetteOrientation.LEFT)
+    assert plaquette_left.name == "ZXXZ_basis(X)_VERTICAL_datainit(X)_datameas(X)_LEFT"
     assert plaquette_left.qubits == PlaquetteQubits(
         data_qubits=qubits.get_qubits_on_side(PlaquetteSide.RIGHT),
         syndrome_qubits=qubits.syndrome_qubits,
@@ -309,6 +321,9 @@ TICK
 M 0 1 2
 """)
     plaquette_right = plaquette.project_on_boundary(PlaquetteOrientation.RIGHT)
+    assert (
+        plaquette_right.name == "ZXXZ_basis(X)_VERTICAL_datainit(X)_datameas(X)_RIGHT"
+    )
     assert plaquette_right.qubits == PlaquetteQubits(
         data_qubits=qubits.get_qubits_on_side(PlaquetteSide.LEFT),
         syndrome_qubits=qubits.syndrome_qubits,
@@ -343,6 +358,7 @@ def test_zxxz_surface_code_init_meas_only_on_side() -> None:
     plaquette = make_zxxz_surface_code_plaquette(
         "X", ResetBasis.X, init_meas_only_on_side=PlaquetteSide.RIGHT
     )
+    assert plaquette.name == "ZXXZ_basis(X)_VERTICAL_datainit(X,RIGHT)"
     circuit = plaquette.circuit.get_circuit()
     assert circuit.has_flow(stim.Flow("1 -> _ZXXZ xor rec[-1]"))
     assert circuit == stim.Circuit("""
@@ -376,6 +392,7 @@ M 0
         data_measurement=MeasurementBasis.Z,
         init_meas_only_on_side=PlaquetteSide.UP,
     )
+    assert plaquette.name == "ZXXZ_basis(Z)_VERTICAL_datameas(Z,UP)"
     circuit = plaquette.circuit.get_circuit()
     assert circuit.has_flow(stim.Flow("1 -> ___XZ xor rec[-1] xor rec[-2] xor rec[-3]"))
     assert circuit == stim.Circuit("""

--- a/src/tqec/plaquette/plaquette.py
+++ b/src/tqec/plaquette/plaquette.py
@@ -65,6 +65,9 @@ class Plaquette:
     def __hash__(self) -> int:
         return hash(self.name)
 
+    def __str__(self) -> str:
+        return self.name
+
     def project_on_boundary(
         self, projected_orientation: PlaquetteOrientation
     ) -> Plaquette:

--- a/src/tqec/plaquette/plaquette.py
+++ b/src/tqec/plaquette/plaquette.py
@@ -60,14 +60,10 @@ class Plaquette:
         return Position2D(0, 0)
 
     def __eq__(self, rhs: object) -> bool:
-        return (
-            isinstance(rhs, Plaquette)
-            and self.qubits == rhs.qubits
-            and self.circuit == rhs.circuit
-        )
+        return isinstance(rhs, Plaquette) and self.name == rhs.name
 
     def __hash__(self) -> int:
-        return hash((self.qubits, str(self.circuit.get_circuit())))
+        return hash(self.name)
 
     def project_on_boundary(
         self, projected_orientation: PlaquetteOrientation

--- a/src/tqec/plaquette/plaquette.py
+++ b/src/tqec/plaquette/plaquette.py
@@ -40,6 +40,7 @@ class Plaquette:
             `qubits`.
     """
 
+    name: str
     qubits: PlaquetteQubits
     circuit: ScheduledCircuit
     mergeable_instructions: frozenset[str] = field(default_factory=frozenset)
@@ -98,7 +99,10 @@ class Plaquette:
             new_plaquette_qubits.all_qubits
         )
         return Plaquette(
-            new_plaquette_qubits, new_scheduled_circuit, self.mergeable_instructions
+            f"{self.name}_{projected_orientation.name}",
+            new_plaquette_qubits,
+            new_scheduled_circuit,
+            self.mergeable_instructions,
         )
 
 

--- a/src/tqec/plaquette/plaquette.py
+++ b/src/tqec/plaquette/plaquette.py
@@ -27,6 +27,11 @@ class Plaquette:
     X-axis pointing to the right and a Y-axis pointing down.
 
     Attributes:
+        name: a unique name for the plaquette. This field is used to compare
+            plaquettes efficiently (two :class:`Plaquette` instances are
+            considered equal if and only if their names are the same) as well as
+            computing a hash value for any plaquette instance. Finally, the name
+            is used to represent a :class:`Plaquette` instance as a string.
         qubits: qubits used by the plaquette circuit, given in the local
             plaquette coordinate system.
         circuit: scheduled quantum circuit implementing the computation that


### PR DESCRIPTION
This PR adds a descriptive `name` field to each `Plaquette` instance. Because `Plaquette` instances are frozen, it also uses this unique name to implement `__eq__` and `__hash__`. Finally, it uses the name to represent a plaquette with `__str__`.

Fixes #360.