### PR TITLE
`DetectorDatabase` is now implemented with a translation-invariant key system

### DIFF
--- a/src/tqec/compile/detectors/database.py
+++ b/src/tqec/compile/detectors/database.py
@@ -25,7 +25,7 @@ def _NUMPY_ARRAY_HASHER(arr: npt.NDArray[numpy.int_]) -> int:
 
 
 @dataclass(frozen=True)
-class DetectorDatabaseKey:
+class _DetectorDatabaseKey:
     """Immutable type used as a key in the database of detectors.
 
     This class represents a "situation" for which we might be able to compute
@@ -90,7 +90,7 @@ class DetectorDatabaseKey:
 
     def __eq__(self, rhs: object) -> bool:
         return (
-            isinstance(rhs, DetectorDatabaseKey)
+            isinstance(rhs, _DetectorDatabaseKey)
             and len(self.subtemplates) == len(rhs.subtemplates)
             and all(
                 bool(numpy.all(self_st == rhs_st))
@@ -138,7 +138,7 @@ class DetectorDatabase:
     computation.
     """
 
-    mapping: dict[DetectorDatabaseKey, frozenset[Detector]] = field(
+    mapping: dict[_DetectorDatabaseKey, frozenset[Detector]] = field(
         default_factory=dict
     )
     frozen: bool = False
@@ -169,7 +169,7 @@ class DetectorDatabase:
         """
         if self.frozen:
             raise TQECException("Cannot add a situation to a frozen database.")
-        key = DetectorDatabaseKey(subtemplates, plaquettes_by_timestep)
+        key = _DetectorDatabaseKey(subtemplates, plaquettes_by_timestep)
         self.mapping[key] = (
             frozenset([detectors]) if isinstance(detectors, Detector) else detectors
         )
@@ -195,7 +195,7 @@ class DetectorDatabase:
         """
         if self.frozen:
             raise TQECException("Cannot remove a situation to a frozen database.")
-        key = DetectorDatabaseKey(subtemplates, plaquettes_by_timestep)
+        key = _DetectorDatabaseKey(subtemplates, plaquettes_by_timestep)
         del self.mapping[key]
 
     def get_detectors(
@@ -220,7 +220,7 @@ class DetectorDatabase:
             detectors associated with the provided situation or `None` if the
             situation is not in the database.
         """
-        key = DetectorDatabaseKey(subtemplates, plaquettes_by_timestep)
+        key = _DetectorDatabaseKey(subtemplates, plaquettes_by_timestep)
         return self.mapping.get(key)
 
     def freeze(self) -> None:

--- a/src/tqec/compile/detectors/database.py
+++ b/src/tqec/compile/detectors/database.py
@@ -5,9 +5,6 @@ from dataclasses import dataclass, field
 from functools import cached_property
 from typing import Sequence
 
-import numpy
-import numpy.typing as npt
-
 from tqec.circuit.generation import generate_circuit_from_instantiation
 from tqec.circuit.measurement_map import MeasurementRecordsMap
 from tqec.circuit.moment import Moment
@@ -21,10 +18,6 @@ from tqec.exceptions import TQECException
 from tqec.plaquette.plaquette import Plaquettes
 from tqec.position import Displacement
 from tqec.templates.subtemplates import SubTemplateType
-
-
-def _NUMPY_ARRAY_HASHER(arr: npt.NDArray[numpy.int_]) -> int:
-    return int(hashlib.md5(arr.data.tobytes(), usedforsecurity=False).hexdigest(), 16)
 
 
 @dataclass(frozen=True)

--- a/src/tqec/compile/detectors/database.py
+++ b/src/tqec/compile/detectors/database.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 import hashlib
 from dataclasses import dataclass, field
+from functools import cached_property
 from typing import Sequence
 
 import numpy
@@ -43,25 +46,19 @@ class _DetectorDatabaseKey:
 
     ## Implementation details
 
-    This class stores data types that are not efficiently hashable (i.e., not in
-    constant time) when considering their values:
+    This class uses a surjective representation to compare (`__eq__`) and hash
+    (`__hash__`) its instances. This representation is computed and cached using
+    the :meth:`_DetectorDatabaseKey.plaquette_names` property that basically
+    uses the provided subtemplates to build a nested tuple data-structure with
+    the same shape as `self.subtemplates` (3 dimensions, the first one being the
+    number of time steps, the next 2 ones being of odd and equal size and
+    depending on the radius used to build subtemplates) storing in each of its
+    entries the corresponding plaquette name.
 
-    - `self.subtemplates` is a raw array of integers without any guarantee on the
-      stored values except that they are positive.
-    - `self.plaquettes_by_timestep` contains :class:`Plaquette` instances, each
-      containing a class:`ScheduledCircuit` instance, ultimately containing a
-      `stim.Circuit`. Hashing a quantum circuit cannot be performed in constant
-      time.
-
-    For `self.subtemplates`, we hash the `shape` of the array as well as the
-    hash of the array's data. This is a constant time operation, because
-    we only consider spatially local detectors at the moment and that
-    restriction makes sub-templates that are of constant size (w.r.t the number
-    of qubits).
-
-    For `self.plaquettes_by_timestep`, we rely on the hash implementation of
-    :class:`Plaquettes`. It is up to :class:`Plaquettes` to implement hash
-    efficiently.
+    This intermediate data-structure is not the most memory efficient one, but
+    it has the advantage of being easy to construct, trivially invariant to
+    plaquette re-indexing and easy to hash (with some care to NOT use Python's
+    default `hash` due to its absence of stability across different runs).
     """
 
     subtemplates: Sequence[SubTemplateType]
@@ -79,24 +76,28 @@ class _DetectorDatabaseKey:
     def num_timeslices(self) -> int:
         return len(self.subtemplates)
 
-    def __hash__(self) -> int:
-        return hash(
-            (
-                tuple(st.shape for st in self.subtemplates),
-                tuple(_NUMPY_ARRAY_HASHER(st) for st in self.subtemplates),
-                tuple(self.plaquettes_by_timestep),
-            )
+    @cached_property
+    def plaquette_names(self) -> tuple[tuple[tuple[str, ...], ...], ...]:
+        return tuple(
+            tuple(tuple(plaquettes[pi].name for pi in row) for row in st)
+            for st, plaquettes in zip(self.subtemplates, self.plaquettes_by_timestep)
         )
+
+    def reliable_hash(self) -> int:
+        hasher = hashlib.md5()
+        for timeslice in self.plaquette_names:
+            for row in timeslice:
+                for name in row:
+                    hasher.update(name.encode())
+        return int(hasher.hexdigest(), 16)
+
+    def __hash__(self) -> int:
+        return self.reliable_hash()
 
     def __eq__(self, rhs: object) -> bool:
         return (
             isinstance(rhs, _DetectorDatabaseKey)
-            and len(self.subtemplates) == len(rhs.subtemplates)
-            and all(
-                bool(numpy.all(self_st == rhs_st))
-                for self_st, rhs_st in zip(self.subtemplates, rhs.subtemplates)
-            )
-            and self.plaquettes_by_timestep == rhs.plaquettes_by_timestep
+            and self.plaquette_names == rhs.plaquette_names
         )
 
     def circuit(self, plaquette_increments: Displacement) -> ScheduledCircuit:

--- a/src/tqec/compile/detectors/database_test.py
+++ b/src/tqec/compile/detectors/database_test.py
@@ -71,7 +71,6 @@ SUBTEMPLATES: list[SubTemplateType] = list(
                 QubitTemplate().instantiate(k=10), manhattan_radius=2
             ).subtemplates.values()
         ),
-        axis=0,
     )
 )
 

--- a/src/tqec/compile/detectors/database_test.py
+++ b/src/tqec/compile/detectors/database_test.py
@@ -143,14 +143,14 @@ def test_detector_database_key_hash() -> None:
     # This is a value that has been pre-computed locally. It is hard-coded here
     # to check that the hash of a dbkey is reliable and does not change depending
     # on the Python interpreter, Python version, host OS, process ID, ...
-    assert hash(dbkey) == 6635855037027289589
+    assert hash(dbkey) == 1085786788918911944
 
     dbkey = _DetectorDatabaseKey(SUBTEMPLATES[:1], PLAQUETTE_COLLECTIONS[:1])
     assert hash(dbkey) == hash(dbkey)
     # This is a value that has been pre-computed locally. It is hard-coded here
     # to check that the hash of a dbkey is reliable and does not change depending
     # on the Python interpreter, Python version, host OS, process ID, ...
-    assert hash(dbkey) == -8009786746945676048
+    assert hash(dbkey) == 1699471538780763110
 
 
 def test_detector_database_creation() -> None:
@@ -209,3 +209,15 @@ def test_detector_database_freeze() -> None:
     detectors2 = db.get_detectors(SUBTEMPLATES[:4], PLAQUETTE_COLLECTIONS[:4])
     assert detectors2 is not None
     assert detectors2 == DETECTORS[1]
+
+
+def test_detector_database_translation_invariance() -> None:
+    db = DetectorDatabase()
+    db.add_situation(SUBTEMPLATES[:1], PLAQUETTE_COLLECTIONS[:1], DETECTORS[0])
+
+    offset = 36
+    translated_subtemplate = SUBTEMPLATES[0] + offset
+    translated_plaquettes = PLAQUETTE_COLLECTIONS[0].map_indices(lambda i: i + offset)
+    detectors = db.get_detectors((translated_subtemplate,), (translated_plaquettes,))
+    assert detectors is not None
+    assert detectors == DETECTORS[0]

--- a/src/tqec/compile/detectors/database_test.py
+++ b/src/tqec/compile/detectors/database_test.py
@@ -4,7 +4,7 @@ import pytest
 from tqec.circuit.coordinates import StimCoordinates
 from tqec.circuit.measurement import Measurement
 from tqec.circuit.qubit import GridQubit
-from tqec.compile.detectors.database import DetectorDatabase, DetectorDatabaseKey
+from tqec.compile.detectors.database import DetectorDatabase, _DetectorDatabaseKey
 from tqec.compile.detectors.detector import Detector
 from tqec.compile.specs.library._utils import _build_plaquettes_for_rotated_surface_code
 from tqec.exceptions import TQECException
@@ -118,20 +118,20 @@ DETECTORS: list[frozenset[Detector]] = [
 
 
 def test_detector_database_key_creation() -> None:
-    DetectorDatabaseKey((SUBTEMPLATES[0],), (PLAQUETTE_COLLECTIONS[0],))
-    DetectorDatabaseKey(SUBTEMPLATES[1:5], PLAQUETTE_COLLECTIONS[1:5])
+    _DetectorDatabaseKey((SUBTEMPLATES[0],), (PLAQUETTE_COLLECTIONS[0],))
+    _DetectorDatabaseKey(SUBTEMPLATES[1:5], PLAQUETTE_COLLECTIONS[1:5])
     with pytest.raises(
         TQECException,
         match="^DetectorDatabaseKey can only store an equal number of "
         "subtemplates and plaquettes. Got 4 subtemplates and 3 plaquettes.$",
     ):
-        DetectorDatabaseKey(SUBTEMPLATES[1:5], PLAQUETTE_COLLECTIONS[1:4])
+        _DetectorDatabaseKey(SUBTEMPLATES[1:5], PLAQUETTE_COLLECTIONS[1:4])
 
 
 def test_detector_database_key_num_timeslices() -> None:
     for i in range(min(len(PLAQUETTE_COLLECTIONS), len(SUBTEMPLATES))):
         assert (
-            DetectorDatabaseKey(
+            _DetectorDatabaseKey(
                 SUBTEMPLATES[:i], PLAQUETTE_COLLECTIONS[:i]
             ).num_timeslices
             == i
@@ -139,14 +139,14 @@ def test_detector_database_key_num_timeslices() -> None:
 
 
 def test_detector_database_key_hash() -> None:
-    dbkey = DetectorDatabaseKey(SUBTEMPLATES[1:5], PLAQUETTE_COLLECTIONS[1:5])
+    dbkey = _DetectorDatabaseKey(SUBTEMPLATES[1:5], PLAQUETTE_COLLECTIONS[1:5])
     assert hash(dbkey) == hash(dbkey)
     # This is a value that has been pre-computed locally. It is hard-coded here
     # to check that the hash of a dbkey is reliable and does not change depending
     # on the Python interpreter, Python version, host OS, process ID, ...
     assert hash(dbkey) == 6635855037027289589
 
-    dbkey = DetectorDatabaseKey(SUBTEMPLATES[:1], PLAQUETTE_COLLECTIONS[:1])
+    dbkey = _DetectorDatabaseKey(SUBTEMPLATES[:1], PLAQUETTE_COLLECTIONS[:1])
     assert hash(dbkey) == hash(dbkey)
     # This is a value that has been pre-computed locally. It is hard-coded here
     # to check that the hash of a dbkey is reliable and does not change depending

--- a/src/tqec/plaquette/frozendefaultdict.py
+++ b/src/tqec/plaquette/frozendefaultdict.py
@@ -94,3 +94,9 @@ class FrozenDefaultDict(Generic[K, V], Mapping[K, V]):
 
     def has_default_factory(self) -> bool:
         return self._default_factory is not None
+
+    def map_keys(self, callable: Callable[[K], K]) -> FrozenDefaultDict:
+        return FrozenDefaultDict(
+            {callable(k): v for k, v in self.items()},
+            default_factory=self._default_factory,
+        )

--- a/src/tqec/plaquette/frozendefaultdict.py
+++ b/src/tqec/plaquette/frozendefaultdict.py
@@ -82,14 +82,12 @@ class FrozenDefaultDict(Generic[K, V], Mapping[K, V]):
         return (
             isinstance(other, FrozenDefaultDict)
             and (
-                not operator.xor(
-                    self._default_factory is None, other._default_factory is None
+                (self._default_factory is None and other._default_factory is None)
+                or (
+                    self._default_factory is not None
+                    and other._default_factory is not None
+                    and (self._default_factory() == other._default_factory())
                 )
-            )
-            and (
-                self._default_factory is not None
-                and other._default_factory is not None
-                and (self._default_factory() == other._default_factory())
             )
             and self._dict == other._dict
         )

--- a/src/tqec/plaquette/frozendefaultdict.py
+++ b/src/tqec/plaquette/frozendefaultdict.py
@@ -95,7 +95,7 @@ class FrozenDefaultDict(Generic[K, V], Mapping[K, V]):
     def has_default_factory(self) -> bool:
         return self._default_factory is not None
 
-    def map_keys(self, callable: Callable[[K], K]) -> FrozenDefaultDict:
+    def map_keys(self, callable: Callable[[K], K]) -> FrozenDefaultDict[K, V]:
         return FrozenDefaultDict(
             {callable(k): v for k, v in self.items()},
             default_factory=self._default_factory,

--- a/src/tqec/plaquette/plaquette.py
+++ b/src/tqec/plaquette/plaquette.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import hashlib
 from collections import defaultdict
 from dataclasses import dataclass, field
-from typing import Mapping
+from typing import Callable, Mapping
 
 from typing_extensions import override
 
@@ -151,6 +151,9 @@ class Plaquettes:
         self, plaquettes_to_update: Mapping[int, Plaquette]
     ) -> Plaquettes:
         return Plaquettes(self.collection | plaquettes_to_update)
+
+    def map_indices(self, callable: Callable[[int], int]) -> Plaquettes:
+        return Plaquettes(self.collection.map_keys(callable))
 
     def __eq__(self, rhs: object) -> bool:
         return isinstance(rhs, Plaquettes) and self.collection == rhs.collection


### PR DESCRIPTION
This PR fixes #374 and refactor a little bit `DetectorDatabase` and its accompanying key data-structure `_DetectorDatabaseKey` to:

1. be translation free, meaning that now equivalent pairs of subtemplates/plaquettes are mapped to the same database entry.
2. use a simpler hashing method that is fully contained in the `database.py` (and not spread in the different data-structures used) and only require that `Plaquette.name` is a valid way of comparing/hashing plaquettes (i.e., the following assertion should hold: "two plaquettes have the same name iff they are equal").