### PR TITLE
Refactor `tqec.circuit.schedule` into submodules

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,12 +6,12 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.17.0
+    rev: v3.19.0
     hooks:
       - id: pyupgrade
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.6.9
+    rev: v0.7.0
     hooks:
       # Run the linter.
       - id: ruff
@@ -21,14 +21,13 @@ repos:
       - id: ruff-format
         types_or: [python, pyi, jupyter]
   - repo: https://github.com/crate-ci/typos
-    rev: v1.25.0
+    rev: v1.26.1
     hooks:
       - id: typos
   - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.20.0
+    rev: v8.21.1
     hooks:
       - id: gitleaks
-  # TODO: re-enable when https://github.com/PyCQA/docformatter/issues/289 is fixed
   # - repo: https://github.com/PyCQA/docformatter
   #   rev: v1.7.5
   #   hooks:

--- a/src/tqec/circuit/schedule/__init__.py
+++ b/src/tqec/circuit/schedule/__init__.py
@@ -1,0 +1,8 @@
+from .circuit import ScheduledCircuit as ScheduledCircuit
+from .exception import ScheduleException as ScheduleException
+from .manipulation import merge_scheduled_circuits as merge_scheduled_circuits
+from .manipulation import (
+    relabel_circuits_qubit_indices as relabel_circuits_qubit_indices,
+)
+from .manipulation import remove_duplicate_instructions as remove_duplicate_instructions
+from .schedule import Schedule as Schedule

--- a/src/tqec/circuit/schedule/circuit_test.py
+++ b/src/tqec/circuit/schedule/circuit_test.py
@@ -1,20 +1,11 @@
-import random
-
 import pytest
 import stim
 
 from tqec.circuit.moment import Moment
 from tqec.circuit.qubit import GridQubit
 from tqec.circuit.qubit_map import QubitMap
-from tqec.circuit.schedule import (
-    Schedule,
-    ScheduledCircuit,
-    ScheduleException,
-    merge_scheduled_circuits,
-    relabel_circuits_qubit_indices,
-    remove_duplicate_instructions,
-)
-from tqec.exceptions import TQECException, TQECWarning
+from tqec.circuit.schedule import Schedule, ScheduledCircuit, ScheduleException
+from tqec.exceptions import TQECException
 
 _VALID_SCHEDULED_CIRCUITS = [
     stim.Circuit(""),
@@ -28,88 +19,6 @@ _VALID_SCHEDULED_CIRCUITS = [
         "TICK\nCX 0 1\nTICK\nM 0 1"
     ),
 ]
-
-
-def test_schedule_construction() -> None:
-    Schedule([])
-    Schedule([0])
-    Schedule([0, 2, 4, 6])
-    Schedule(list(range(100000)))
-
-    with pytest.raises(ScheduleException):
-        Schedule([-2, 0, 1])
-    with pytest.raises(ScheduleException):
-        Schedule([0, 1, 1, 2])
-    with pytest.raises(ScheduleException):
-        Schedule([1, 0])
-
-
-def test_schedule_from_offset() -> None:
-    Schedule.from_offsets([])
-    Schedule.from_offsets([0])
-    Schedule.from_offsets([0, 2, 4, 6])
-    Schedule.from_offsets(list(range(100000)))
-
-    with pytest.raises(ScheduleException):
-        Schedule.from_offsets([-2, 0, 1])
-    with pytest.raises(ScheduleException):
-        Schedule.from_offsets([0, 1, 1, 2])
-    with pytest.raises(ScheduleException):
-        Schedule.from_offsets([1, 0])
-
-
-def test_schedule_len() -> None:
-    assert len(Schedule([])) == 0
-    assert len(Schedule([0])) == 1
-    assert len(Schedule([0, 2, 4, 6])) == 4
-    assert len(Schedule(list(range(100000)))) == 100000
-
-
-def test_schedule_getitem() -> None:
-    with pytest.raises(IndexError):
-        Schedule([])[0]
-    with pytest.raises(IndexError):
-        Schedule([])[-1]
-    assert Schedule([0])[0] == 0
-    assert Schedule([0, 2, 4, 6])[2] == 4
-    assert Schedule([0, 2, 4, 6])[-1] == 6
-    sched = Schedule(list(range(100000)))
-    for i in (random.randint(0, 99999) for _ in range(100)):
-        assert sched[i] == i
-
-
-def test_schedule_iter() -> None:
-    assert list(Schedule([])) == []
-    assert list(Schedule([0, 5, 6])) == [0, 5, 6]
-    assert list(Schedule(list(range(100000)))) == list(range(100000))
-
-
-def test_schedule_append_schedule() -> None:
-    sched = Schedule(list(range(10)))
-    sched.append_schedule(sched)
-    assert sched.schedule == list(range(20))
-
-
-def test_schedule_insert() -> None:
-    schedule = Schedule([0, 3])
-    with pytest.raises(ScheduleException):
-        schedule.insert(0, -1)
-    assert schedule.schedule == [0, 3]
-    schedule.insert(1, 1)
-    assert schedule.schedule == [0, 1, 3]
-    schedule.insert(-1, 2)
-    assert schedule.schedule == [0, 1, 2, 3]
-
-
-def test_schedule_append() -> None:
-    schedule = Schedule([0, 3])
-    with pytest.raises(ScheduleException):
-        schedule.append(-1)
-    assert schedule.schedule == [0, 3]
-    schedule.append(4)
-    assert schedule.schedule == [0, 3, 4]
-    schedule.append(5)
-    assert schedule.schedule == [0, 3, 4, 5]
 
 
 def test_scheduled_circuit_construction() -> None:
@@ -342,100 +251,3 @@ def test_scheduled_circuit_filter_by_qubit() -> None:
     filtered_circuit = circuit.filter_by_qubits([GridQubit(0, 0), GridQubit(0, 1)])
     assert filtered_circuit.get_circuit() == stim.Circuit("QUBIT_COORDS(0, 0) 0\nH 0")
     assert filtered_circuit.schedule == Schedule([0])
-
-
-def test_remove_duplicate_instructions() -> None:
-    instructions: list[stim.CircuitInstruction] = list(
-        iter(stim.Circuit("H 0 0 0 2 0 0 0 0 1 1 2 2 0 0 0 3"))
-    )  # type: ignore
-    expected_instructions = set(iter(stim.Circuit("H 0 1 2 3")))  # type: ignore
-    assert (
-        set(remove_duplicate_instructions(instructions, frozenset(["H"])))
-        == expected_instructions
-    )
-    with pytest.warns(TQECWarning):
-        # Several H gates are overlapping, which means that the returned instruction
-        # list is not a valid Moment, which should raise a warning.
-        assert remove_duplicate_instructions(instructions, frozenset()) == instructions
-
-    instructions = list(iter(stim.Circuit("H 0 1 2 3 0 1 2 3\nM 4 5 6 4 5 6 4 5 6")))  # type: ignore
-    with pytest.warns(TQECWarning):
-        assert set(
-            remove_duplicate_instructions(instructions, frozenset(["M"]))
-        ) == set(iter(stim.Circuit("H 0 1 2 3 0 1 2 3\nM 4 5 6")))
-    with pytest.warns(TQECWarning):
-        assert set(
-            remove_duplicate_instructions(instructions, frozenset(["H"]))
-        ) == set(iter(stim.Circuit("H 0 1 2 3\nM 4 5 6 4 5 6 4 5 6")))
-    assert set(
-        remove_duplicate_instructions(instructions, frozenset(["H", "M"]))
-    ) == set(iter(stim.Circuit("H 0 1 2 3\nM 4 5 6")))
-
-
-def test_relabel_circuits_qubit_indices() -> None:
-    # Any qubit target not defined by a QUBIT_COORDS instruction should raise
-    # an exception.
-    with pytest.raises(KeyError):
-        relabel_circuits_qubit_indices(
-            [
-                ScheduledCircuit.from_circuit(stim.Circuit("H 0 1 2")),
-                ScheduledCircuit.from_circuit(stim.Circuit("H 0 1 2")),
-            ]
-        )
-    with pytest.raises(KeyError):
-        relabel_circuits_qubit_indices(
-            [
-                ScheduledCircuit.from_circuit(
-                    stim.Circuit("QUBIT_COORDS(0, 0) 0\nH 0")
-                ),
-                ScheduledCircuit.from_circuit(stim.Circuit("H 0")),
-            ]
-        )
-    circuits, q2i = relabel_circuits_qubit_indices(
-        [
-            ScheduledCircuit.from_circuit(stim.Circuit("QUBIT_COORDS(0, 0) 0\nH 0")),
-            ScheduledCircuit.from_circuit(stim.Circuit("QUBIT_COORDS(1, 1) 0\nX 0")),
-        ]
-    )
-    assert q2i == QubitMap({0: GridQubit(0, 0), 1: GridQubit(1, 1)})
-    assert len(circuits) == 2
-    assert circuits[0].get_circuit() == stim.Circuit("QUBIT_COORDS(0, 0) 0\nH 0")
-    assert circuits[1].get_circuit() == stim.Circuit("QUBIT_COORDS(1, 1) 1\nX 1")
-
-
-def test_merge_scheduled_circuits() -> None:
-    # Any qubit target not defined by a QUBIT_COORDS instruction should raise
-    # an exception.
-    _circuits, _qubit_map = relabel_circuits_qubit_indices(
-        [
-            ScheduledCircuit.from_circuit(stim.Circuit("QUBIT_COORDS(0, 0) 0\nH 0")),
-            ScheduledCircuit.from_circuit(stim.Circuit("QUBIT_COORDS(1, 1) 0\nX 0")),
-        ]
-    )
-    circuit = merge_scheduled_circuits(_circuits, _qubit_map)
-    assert circuit.get_circuit() == stim.Circuit(
-        "QUBIT_COORDS(0, 0) 0\nQUBIT_COORDS(1, 1) 1\nH 0\nX 1"
-    )
-
-    circuit = merge_scheduled_circuits(
-        [
-            ScheduledCircuit.from_circuit(stim.Circuit("QUBIT_COORDS(0, 0) 0\nH 0")),
-            ScheduledCircuit.from_circuit(stim.Circuit("QUBIT_COORDS(0, 0) 0\nH 0")),
-        ],
-        global_qubit_map=QubitMap({0: GridQubit(0, 0)}),
-        mergeable_instructions=["H"],
-    )
-    assert circuit.get_circuit() == stim.Circuit("QUBIT_COORDS(0, 0) 0\nH 0")
-
-    _circuits, _qubit_map = relabel_circuits_qubit_indices(
-        [
-            ScheduledCircuit.from_circuit(
-                stim.Circuit("QUBIT_COORDS(0, 0) 0\nH 0\nTICK\nM 0"), [0, 2]
-            ),
-            ScheduledCircuit.from_circuit(stim.Circuit("QUBIT_COORDS(1, 1) 0\nX 0"), 1),
-        ]
-    )
-    circuit = merge_scheduled_circuits(_circuits, _qubit_map)
-    assert circuit.get_circuit() == stim.Circuit(
-        "QUBIT_COORDS(0, 0) 0\nQUBIT_COORDS(1, 1) 1\nH 0\nTICK\nX 1\nTICK\nM 0"
-    )

--- a/src/tqec/circuit/schedule/exception.py
+++ b/src/tqec/circuit/schedule/exception.py
@@ -1,0 +1,5 @@
+from tqec.exceptions import TQECException
+
+
+class ScheduleException(TQECException):
+    pass

--- a/src/tqec/circuit/schedule/manipulation.py
+++ b/src/tqec/circuit/schedule/manipulation.py
@@ -1,0 +1,335 @@
+"""Defines the :class:`ScheduledCircuit` class.
+
+This module is central to the `tqec` library because it implements one of the
+most used class of the library: :class:`ScheduledCircuit`.
+
+A :class:`ScheduledCircuit` is "simply" a `stim.Circuit` that have all its
+moments (portions of computation between two `TICK` instructions) assigned to
+a unique positive integer representing the time slice at which the moment should
+be scheduled.
+
+Alongside :class:`ScheduledCircuit`, this module defines:
+
+- :class:`Schedule` that is a thin wrapper around `list[int]` to represent a
+  schedule (a sorted list of non-duplicated positive integers).
+- :func:`remove_duplicate_instructions` to remove some instructions appearing
+  twice in a single moment (most of the time due to data qubit
+  reset/measurements that are defined by each plaquette, even on qubits shared
+  with other plaquettes, leading to duplicates).
+- :func:`merge_scheduled_circuits` that merge several :class:`ScheduledCircuit`
+  instances into one.
+- :func:`relabel_circuits_qubit_indices` to prepare several
+  :class:`ScheduledCircuit` before merging them. This function is called
+  internally by :func:`merge_scheduled_circuits` but might be useful at other
+  places and so is kept public.
+"""
+
+from __future__ import annotations
+
+import itertools
+import warnings
+from typing import Iterable, Sequence
+
+import stim
+
+from tqec.circuit.moment import Moment
+from tqec.circuit.qubit import GridQubit
+from tqec.circuit.qubit_map import QubitMap
+from tqec.circuit.schedule.circuit import ScheduledCircuit
+from tqec.circuit.schedule.schedule import Schedule
+from tqec.exceptions import TQECException, TQECWarning
+
+
+class _ScheduledCircuits:
+    def __init__(
+        self, circuits: list[ScheduledCircuit], global_qubit_map: QubitMap
+    ) -> None:
+        """Represents a collection of :class`ScheduledCircuit` instances.
+
+        This class aims at providing accessors for several compatible instances
+        of :class:`ScheduledCircuit`. It allows to iterate on gates globally, for
+        all the managed instances of :class:`ScheduledCircuit`, and implement a
+        few other accessor methods to help with the task of merging multiple
+        :class`ScheduledCircuit` together.
+
+        Args:
+            circuits: the instances that should be managed. Note that the
+                instances provided here have to be "compatible" with each
+                other.
+            global_qubit_map: a unique qubit map that can be used to map qubits
+                to indices for all the provided `circuits`.
+        """
+        # We might need to remap qubits to avoid index collision on several
+        # circuits.
+        self._circuits = circuits
+        self._global_qubit_map = global_qubit_map
+        self._iterators = [circuit.scheduled_moments for circuit in self._circuits]
+        self._current_moments = [next(it, None) for it in self._iterators]
+
+    def has_pending_moment(self) -> bool:
+        """Checks if any of the managed instances has a pending moment.
+
+        Any moment that has not been collected by using collect_moment
+        is considered to be pending.
+        """
+        return any(self._has_pending_moment(i) for i in range(len(self._circuits)))
+
+    def _has_pending_moment(self, index: int) -> bool:
+        """Check if the managed instance at the given index has a pending
+        operation."""
+        return self._current_moments[index] is not None
+
+    def _peek_scheduled_moment(self, index: int) -> tuple[int, Moment] | None:
+        """Recover **without collecting** the pending operation for the
+        instance at the given index."""
+        return self._current_moments[index]
+
+    def _pop_scheduled_moment(self, index: int) -> tuple[int, Moment]:
+        """Recover and mark as collected the pending moment for the instance at
+        the given index.
+
+        Raises:
+            AssertionError: if not self.has_pending_operation(index).
+        """
+        ret = self._current_moments[index]
+        if ret is None:
+            raise TQECException(
+                "Trying to pop a Moment instance from a ScheduledCircuit with "
+                "all its moments already collected."
+            )
+        self._current_moments[index] = next(self._iterators[index], None)
+        return ret
+
+    @property
+    def number_of_circuits(self) -> int:
+        return len(self._circuits)
+
+    def collect_moments_at_minimum_schedule(self) -> tuple[int, list[Moment]]:
+        """Collect all the moments that can be collected.
+
+        This method collects and returns a list of all the moments that should
+        be scheduled next.
+
+        Returns:
+            a list of :class:`Moment` instances that should be added next to
+            the QEC circuit.
+        """
+        assert self.has_pending_moment()
+        circuit_indices_organised_by_schedule: dict[int, list[int]] = dict()
+        for circuit_index in range(self.number_of_circuits):
+            if not self._has_pending_moment(circuit_index):
+                continue
+            schedule, _ = self._peek_scheduled_moment(circuit_index)  # type: ignore
+            circuit_indices_organised_by_schedule.setdefault(schedule, list()).append(
+                circuit_index
+            )
+
+        minimum_schedule = min(circuit_indices_organised_by_schedule.keys())
+        moments_to_return: list[Moment] = list()
+        for circuit_index in circuit_indices_organised_by_schedule[minimum_schedule]:
+            _, moment = self._pop_scheduled_moment(circuit_index)
+            moments_to_return.append(moment)
+        return minimum_schedule, moments_to_return
+
+    @property
+    def q2i(self) -> dict[GridQubit, int]:
+        return self._global_qubit_map.q2i
+
+
+def _sort_target_groups(
+    targets: Iterable[list[stim.GateTarget]],
+) -> list[list[stim.GateTarget]]:
+    def _sort_key(target_group: Iterable[stim.GateTarget]) -> tuple[int, ...]:
+        return tuple(t.value for t in target_group)
+
+    return sorted(targets, key=_sort_key)
+
+
+def remove_duplicate_instructions(
+    instructions: list[stim.CircuitInstruction],
+    mergeable_instruction_names: frozenset[str],
+) -> list[stim.CircuitInstruction]:
+    """Removes all the duplicate instructions from the given list.
+
+    Note:
+        This function guarantees the following post-conditions on the returned
+        results:
+
+        - Instructions with a name that is not in `mergeable_instruction_names`
+          are returned at the front of the returned list, in the same relative
+          ordering as provided in `instructions` input.
+        - Instructions with a name that is in `mergeable_instruction_names` will
+          be returned after all the instructions with a name that does not
+          appear in `mergeable_instruction_names`. The order in which these
+          instructions are returned is not guaranteed and can change between
+          executions.
+
+    Warning:
+        this function **does not keep instruction ordering**. It is intended to
+        be used with input `instructions` that, once de-duplication has been
+        applied, form a valid moment, which means that each instruction can be
+        executed in parallel, and so their order in the returned list does not
+        matter.
+
+        If that is not your case, take extra care to the output of this
+        function as it will likely introduce hard-to-debug issues. To prevent
+        such potential misuse, this function checks for such cases and outputs
+        a warning if it happens.
+
+    Returns:
+        a list containing a copy of the stim.CircuitInstruction instances from
+        the given instructions but without any duplicate.
+    """
+    # Separate mergeable operations from non-mergeable ones.
+    mergeable_operations: dict[
+        tuple[str, tuple[float, ...]], set[tuple[stim.GateTarget, ...]]
+    ] = {}
+    final_operations: list[stim.CircuitInstruction] = list()
+    for inst in instructions:
+        if inst.name in mergeable_instruction_names:
+            # Mergeable operations are automatically merged thanks to
+            # the use of a set here.
+            mergeable_operations.setdefault(
+                (inst.name, tuple(inst.gate_args_copy())), set()
+            ).update(tuple(group) for group in inst.target_groups())
+        else:
+            final_operations.append(inst)
+    # Add the merged operations into the final ones
+    final_operations.extend(
+        stim.CircuitInstruction(
+            name, sum(_sort_target_groups([list(t) for t in targets]), start=[]), args
+        )
+        for (name, args), targets in mergeable_operations.items()
+    )
+    # Warn if the output instructions do not form a valid moment, as this is
+    # likely a misuse of this function.
+    try:
+        circuit = stim.Circuit()
+        for instr in final_operations:
+            circuit.append(instr)
+        Moment.check_is_valid_moment(circuit)
+    except TQECException:
+        warnings.warn(
+            "The instructions obtained at the end of the "
+            "`remove_duplicate_instructions` function do not form a valid "
+            "moment. You are likely misusing the function. Final instructions "
+            "obtained and gathered into a single stim.Circuit: "
+            f"\n{circuit}",
+            TQECWarning,
+        )
+    return final_operations
+
+
+def merge_scheduled_circuits(
+    circuits: list[ScheduledCircuit],
+    global_qubit_map: QubitMap,
+    mergeable_instructions: Iterable[str] = (),
+) -> ScheduledCircuit:
+    """Merge several ScheduledCircuit instances into one instance.
+
+    This function takes several **compatible** scheduled circuits as input and
+    merge them, respecting their schedules, into a unique `ScheduledCircuit`
+    instance that will then be returned to the caller.
+
+    The provided circuits should be compatible between each other. Compatible
+    circuits are circuits that can all be described with a unique global qubit
+    map. In other words, if two circuits from the list of compatible circuits
+    use the same qubit index, that should mean that they use the same qubit.
+    You can obtain compatible circuits by using
+    :func:`relabel_circuits_qubit_indices`.
+
+    Args:
+        circuits: **compatible** circuits to merge.
+        qubit_map: global qubit map for all the provided `circuits`.
+        mergeable_instructions: a list of instruction names that are considered
+            mergeable. Duplicate instructions with a name in this list will be
+            merged into a single instruction.
+
+    Returns:
+        a circuit representing the merged scheduled circuits given as input.
+    """
+    scheduled_circuits = _ScheduledCircuits(circuits, global_qubit_map)
+
+    all_moments: list[Moment] = []
+    all_schedules = Schedule()
+    global_i2q = QubitMap({i: q for q, i in scheduled_circuits.q2i.items()})
+
+    while scheduled_circuits.has_pending_moment():
+        schedule, moments = scheduled_circuits.collect_moments_at_minimum_schedule()
+        # Flatten the moments into a list of operations to perform some modifications
+        instructions = sum((list(moment.instructions) for moment in moments), start=[])
+        # Avoid duplicated operations. Any operation that have the Plaquette.get_mergeable_tag() tag
+        # is considered mergeable, and can be removed if another operation in the list
+        # is considered equal (and has the mergeable tag).
+        deduplicated_instructions = remove_duplicate_instructions(
+            instructions,
+            mergeable_instruction_names=frozenset(mergeable_instructions),
+        )
+        circuit = stim.Circuit()
+        for inst in deduplicated_instructions:
+            circuit.append(
+                inst.name,
+                sum(_sort_target_groups(inst.target_groups()), start=[]),
+                inst.gate_args_copy(),
+            )
+        all_moments.append(Moment(circuit))
+        all_schedules.append(schedule)
+
+    return ScheduledCircuit(all_moments, all_schedules, global_i2q, _avoid_checks=True)
+
+
+def relabel_circuits_qubit_indices(
+    circuits: Sequence[ScheduledCircuit],
+) -> tuple[list[ScheduledCircuit], QubitMap]:
+    """Relabel the qubit indices of the provided circuits to avoid collision.
+
+    When several :class:`ScheduledCircuit` are constructed without a global
+    knowledge of all the qubits, qubit indices used by each instance likely
+    overlap. This is an issue when we try to merge such circuits because one
+    index might represent a different qubit depending on the circuit it is used
+    in.
+
+    This function takes a sequence of circuits and relabel their qubits to avoid
+    such collisions.
+
+    Warning:
+        all the qubit targets used in each of the provided circuits should have
+        a corresponding entry in the circuit qubit map for this function to work
+        correctly. If that is not the case, a KeyError will be raised.
+
+    Raises:
+        KeyError: if any of the provided circuit contains a qubit target that is
+            not present in its qubit map.
+
+    Args:
+        circuits: circuit instances to remap. This parameter is not mutated by
+            this function and is only used in read-only mode.
+
+    Returns:
+        the same circuits with update qubit indices as well as the global qubit
+        indices map that has been used. Qubits in the returned global qubit map
+        are assigned to an index such that:
+
+        1. the sequence of indices is `range(0, len(qubit_map))`.
+        2. qubits are assigned indices in sorted order.
+    """
+    # First, get a global qubit index map.
+    # Using itertools to avoid the edge case `len(circuits) == 0`
+    needed_qubits = frozenset(
+        itertools.chain.from_iterable([c.qubits for c in circuits])
+    )
+    global_qubit_map = QubitMap.from_qubits(sorted(needed_qubits))
+    global_q2i = global_qubit_map.q2i
+    # Then, get the remapped circuits. Note that map_qubit_indices should
+    # have approximately the same runtime cost whatever the value of inplace
+    # so we ask for a new instance to avoid keeping a reference to the given
+    # circuits.
+    relabeled_circuits: list[ScheduledCircuit] = []
+    for circuit in circuits:
+        local_indices_to_global_indices = {
+            local_index: global_q2i[q] for local_index, q in circuit.qubit_map.items()
+        }
+        relabeled_circuits.append(
+            circuit.map_qubit_indices(local_indices_to_global_indices, inplace=False)
+        )
+    return relabeled_circuits, global_qubit_map

--- a/src/tqec/circuit/schedule/manipulation.py
+++ b/src/tqec/circuit/schedule/manipulation.py
@@ -1,17 +1,7 @@
-"""Defines the :class:`ScheduledCircuit` class.
+"""Defines functions to modify or merge :class:`ScheduledCircuit` instances.
 
-This module is central to the `tqec` library because it implements one of the
-most used class of the library: :class:`ScheduledCircuit`.
+This module implement a few central functions for the ``tqec`` library:
 
-A :class:`ScheduledCircuit` is "simply" a `stim.Circuit` that have all its
-moments (portions of computation between two `TICK` instructions) assigned to
-a unique positive integer representing the time slice at which the moment should
-be scheduled.
-
-Alongside :class:`ScheduledCircuit`, this module defines:
-
-- :class:`Schedule` that is a thin wrapper around `list[int]` to represent a
-  schedule (a sorted list of non-duplicated positive integers).
 - :func:`remove_duplicate_instructions` to remove some instructions appearing
   twice in a single moment (most of the time due to data qubit
   reset/measurements that are defined by each plaquette, even on qubits shared

--- a/src/tqec/circuit/schedule/manipulation_test.py
+++ b/src/tqec/circuit/schedule/manipulation_test.py
@@ -1,0 +1,109 @@
+import pytest
+import stim
+
+from tqec.circuit.qubit import GridQubit
+from tqec.circuit.qubit_map import QubitMap
+from tqec.circuit.schedule.circuit import ScheduledCircuit
+from tqec.circuit.schedule.manipulation import (
+    merge_scheduled_circuits,
+    relabel_circuits_qubit_indices,
+    remove_duplicate_instructions,
+)
+from tqec.exceptions import TQECWarning
+
+
+def test_remove_duplicate_instructions() -> None:
+    instructions: list[stim.CircuitInstruction] = list(
+        iter(stim.Circuit("H 0 0 0 2 0 0 0 0 1 1 2 2 0 0 0 3"))
+    )  # type: ignore
+    expected_instructions = set(iter(stim.Circuit("H 0 1 2 3")))  # type: ignore
+    assert (
+        set(remove_duplicate_instructions(instructions, frozenset(["H"])))
+        == expected_instructions
+    )
+    with pytest.warns(TQECWarning):
+        # Several H gates are overlapping, which means that the returned instruction
+        # list is not a valid Moment, which should raise a warning.
+        assert remove_duplicate_instructions(instructions, frozenset()) == instructions
+
+    instructions = list(iter(stim.Circuit("H 0 1 2 3 0 1 2 3\nM 4 5 6 4 5 6 4 5 6")))  # type: ignore
+    with pytest.warns(TQECWarning):
+        assert set(
+            remove_duplicate_instructions(instructions, frozenset(["M"]))
+        ) == set(iter(stim.Circuit("H 0 1 2 3 0 1 2 3\nM 4 5 6")))
+    with pytest.warns(TQECWarning):
+        assert set(
+            remove_duplicate_instructions(instructions, frozenset(["H"]))
+        ) == set(iter(stim.Circuit("H 0 1 2 3\nM 4 5 6 4 5 6 4 5 6")))
+    assert set(
+        remove_duplicate_instructions(instructions, frozenset(["H", "M"]))
+    ) == set(iter(stim.Circuit("H 0 1 2 3\nM 4 5 6")))
+
+
+def test_relabel_circuits_qubit_indices() -> None:
+    # Any qubit target not defined by a QUBIT_COORDS instruction should raise
+    # an exception.
+    with pytest.raises(KeyError):
+        relabel_circuits_qubit_indices(
+            [
+                ScheduledCircuit.from_circuit(stim.Circuit("H 0 1 2")),
+                ScheduledCircuit.from_circuit(stim.Circuit("H 0 1 2")),
+            ]
+        )
+    with pytest.raises(KeyError):
+        relabel_circuits_qubit_indices(
+            [
+                ScheduledCircuit.from_circuit(
+                    stim.Circuit("QUBIT_COORDS(0, 0) 0\nH 0")
+                ),
+                ScheduledCircuit.from_circuit(stim.Circuit("H 0")),
+            ]
+        )
+    circuits, q2i = relabel_circuits_qubit_indices(
+        [
+            ScheduledCircuit.from_circuit(stim.Circuit("QUBIT_COORDS(0, 0) 0\nH 0")),
+            ScheduledCircuit.from_circuit(stim.Circuit("QUBIT_COORDS(1, 1) 0\nX 0")),
+        ]
+    )
+    assert q2i == QubitMap({0: GridQubit(0, 0), 1: GridQubit(1, 1)})
+    assert len(circuits) == 2
+    assert circuits[0].get_circuit() == stim.Circuit("QUBIT_COORDS(0, 0) 0\nH 0")
+    assert circuits[1].get_circuit() == stim.Circuit("QUBIT_COORDS(1, 1) 1\nX 1")
+
+
+def test_merge_scheduled_circuits() -> None:
+    # Any qubit target not defined by a QUBIT_COORDS instruction should raise
+    # an exception.
+    _circuits, _qubit_map = relabel_circuits_qubit_indices(
+        [
+            ScheduledCircuit.from_circuit(stim.Circuit("QUBIT_COORDS(0, 0) 0\nH 0")),
+            ScheduledCircuit.from_circuit(stim.Circuit("QUBIT_COORDS(1, 1) 0\nX 0")),
+        ]
+    )
+    circuit = merge_scheduled_circuits(_circuits, _qubit_map)
+    assert circuit.get_circuit() == stim.Circuit(
+        "QUBIT_COORDS(0, 0) 0\nQUBIT_COORDS(1, 1) 1\nH 0\nX 1"
+    )
+
+    circuit = merge_scheduled_circuits(
+        [
+            ScheduledCircuit.from_circuit(stim.Circuit("QUBIT_COORDS(0, 0) 0\nH 0")),
+            ScheduledCircuit.from_circuit(stim.Circuit("QUBIT_COORDS(0, 0) 0\nH 0")),
+        ],
+        global_qubit_map=QubitMap({0: GridQubit(0, 0)}),
+        mergeable_instructions=["H"],
+    )
+    assert circuit.get_circuit() == stim.Circuit("QUBIT_COORDS(0, 0) 0\nH 0")
+
+    _circuits, _qubit_map = relabel_circuits_qubit_indices(
+        [
+            ScheduledCircuit.from_circuit(
+                stim.Circuit("QUBIT_COORDS(0, 0) 0\nH 0\nTICK\nM 0"), [0, 2]
+            ),
+            ScheduledCircuit.from_circuit(stim.Circuit("QUBIT_COORDS(1, 1) 0\nX 0"), 1),
+        ]
+    )
+    circuit = merge_scheduled_circuits(_circuits, _qubit_map)
+    assert circuit.get_circuit() == stim.Circuit(
+        "QUBIT_COORDS(0, 0) 0\nQUBIT_COORDS(1, 1) 1\nH 0\nTICK\nX 1\nTICK\nM 0"
+    )

--- a/src/tqec/circuit/schedule/schedule.py
+++ b/src/tqec/circuit/schedule/schedule.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import ClassVar, Iterator, Sequence
+
+from tqec.circuit.schedule.exception import ScheduleException
+
+
+@dataclass
+class Schedule:
+    """Thin wrapper around `list[int]` to represent a schedule.
+
+    This class ensures that the list of integers provided is a valid
+    schedule by checking that all entries are positive integers, that
+    the list is sorted and that it does not contain any duplicate.
+    """
+
+    schedule: list[int] = field(default_factory=list)
+
+    _INITIAL_SCHEDULE: ClassVar[int] = 0
+
+    def __post_init__(self) -> None:
+        Schedule._check_schedule(self.schedule)
+
+    @staticmethod
+    def from_offsets(schedule_offsets: Sequence[int]) -> Schedule:
+        """Get a valid schedule from offsets.
+
+        This method should be used to avoid any dependency on
+        `Schedule._INITIAL_SCHEDULE` in user code.
+        """
+        return Schedule([Schedule._INITIAL_SCHEDULE + s for s in schedule_offsets])
+
+    @staticmethod
+    def _check_schedule(schedule: list[int]) -> None:
+        # Check that the schedule is sorted and positive
+        if schedule and (
+            not all(schedule[i] < schedule[i + 1] for i in range(len(schedule) - 1))
+            or schedule[0] < Schedule._INITIAL_SCHEDULE
+        ):
+            raise ScheduleException(
+                f"The provided schedule {schedule} is not a sorted list of positive "
+                "integers. You should only provide sorted schedules with positive "
+                "entries."
+            )
+
+    def __len__(self) -> int:
+        return len(self.schedule)
+
+    def __getitem__(self, i: int) -> int:
+        return self.schedule[i]
+
+    def __iter__(self) -> Iterator[int]:
+        return iter(self.schedule)
+
+    def insert(self, i: int, value: int) -> None:
+        """Insert an integer to the schedule.
+
+        If inserting the integer results in an invalid schedule, the schedule is
+        brought back to its (valid) original state before calling this function
+        and a `ScheduleException` is raised.
+
+        Args:
+            i: index at which the provided value should be inserted.
+            value: value to insert.
+
+        Raises:
+            ScheduleException: if the inserted integer makes the schedule
+                invalid.
+        """
+        self.schedule.insert(i, value)
+        try:
+            Schedule._check_schedule(self.schedule)
+        except ScheduleException as e:
+            self.schedule.pop(i)
+            raise e
+
+    def append(self, value: int) -> None:
+        """Append an integer to the schedule.
+
+        If appending the integer results in an invalid schedule, the schedule is
+        brought back to its (valid) original state before calling this function
+        and a `ScheduleException` is raised.
+
+        Args:
+            value: value to insert.
+
+        Raises:
+            ScheduleException: if the inserted integer makes the schedule
+                invalid.
+        """
+        self.schedule.append(value)
+        try:
+            Schedule._check_schedule(self.schedule)
+        except ScheduleException as e:
+            self.schedule.pop(-1)
+            raise e
+
+    def append_schedule(self, schedule: Schedule) -> None:
+        starting_index = (
+            self.schedule[-1] + 1 if self.schedule else Schedule._INITIAL_SCHEDULE
+        )
+        # Note: not using a generator here but explicitly constructing a list
+        #       because if `schedule == self` a generator would induce an
+        #       infinite loop.
+        self.schedule.extend([starting_index + s for s in schedule.schedule])

--- a/src/tqec/circuit/schedule/schedule_test.py
+++ b/src/tqec/circuit/schedule/schedule_test.py
@@ -1,0 +1,88 @@
+import random
+
+import pytest
+
+from tqec.circuit.schedule.exception import ScheduleException
+from tqec.circuit.schedule.schedule import Schedule
+
+
+def test_schedule_construction() -> None:
+    Schedule([])
+    Schedule([0])
+    Schedule([0, 2, 4, 6])
+    Schedule(list(range(100000)))
+
+    with pytest.raises(ScheduleException):
+        Schedule([-2, 0, 1])
+    with pytest.raises(ScheduleException):
+        Schedule([0, 1, 1, 2])
+    with pytest.raises(ScheduleException):
+        Schedule([1, 0])
+
+
+def test_schedule_from_offset() -> None:
+    Schedule.from_offsets([])
+    Schedule.from_offsets([0])
+    Schedule.from_offsets([0, 2, 4, 6])
+    Schedule.from_offsets(list(range(100000)))
+
+    with pytest.raises(ScheduleException):
+        Schedule.from_offsets([-2, 0, 1])
+    with pytest.raises(ScheduleException):
+        Schedule.from_offsets([0, 1, 1, 2])
+    with pytest.raises(ScheduleException):
+        Schedule.from_offsets([1, 0])
+
+
+def test_schedule_len() -> None:
+    assert len(Schedule([])) == 0
+    assert len(Schedule([0])) == 1
+    assert len(Schedule([0, 2, 4, 6])) == 4
+    assert len(Schedule(list(range(100000)))) == 100000
+
+
+def test_schedule_getitem() -> None:
+    with pytest.raises(IndexError):
+        Schedule([])[0]
+    with pytest.raises(IndexError):
+        Schedule([])[-1]
+    assert Schedule([0])[0] == 0
+    assert Schedule([0, 2, 4, 6])[2] == 4
+    assert Schedule([0, 2, 4, 6])[-1] == 6
+    sched = Schedule(list(range(100000)))
+    for i in (random.randint(0, 99999) for _ in range(100)):
+        assert sched[i] == i
+
+
+def test_schedule_iter() -> None:
+    assert list(Schedule([])) == []
+    assert list(Schedule([0, 5, 6])) == [0, 5, 6]
+    assert list(Schedule(list(range(100000)))) == list(range(100000))
+
+
+def test_schedule_append_schedule() -> None:
+    sched = Schedule(list(range(10)))
+    sched.append_schedule(sched)
+    assert sched.schedule == list(range(20))
+
+
+def test_schedule_insert() -> None:
+    schedule = Schedule([0, 3])
+    with pytest.raises(ScheduleException):
+        schedule.insert(0, -1)
+    assert schedule.schedule == [0, 3]
+    schedule.insert(1, 1)
+    assert schedule.schedule == [0, 1, 3]
+    schedule.insert(-1, 2)
+    assert schedule.schedule == [0, 1, 2, 3]
+
+
+def test_schedule_append() -> None:
+    schedule = Schedule([0, 3])
+    with pytest.raises(ScheduleException):
+        schedule.append(-1)
+    assert schedule.schedule == [0, 3]
+    schedule.append(4)
+    assert schedule.schedule == [0, 3, 4]
+    schedule.append(5)
+    assert schedule.schedule == [0, 3, 4, 5]


### PR DESCRIPTION
This PR fixes #358.

The first commit of this PR splits `src/tqec/circuit/schedule.py` into multiple files in the newly created folder `src/tqec/circuit/schedule/` and re-export all the public symbols in its `__init__.py`.

The subsequent commits will likely implement a `FrozenScheduledCircuit` data structure.